### PR TITLE
fix: CrudRepository 사용으로 인한 원치않은 데이터 삽입

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/CertificationController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/CertificationController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class CertificationController {
 
     private final CertificationService certificationService;
 

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/impl/JoinCodeRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/impl/JoinCodeRepositoryImpl.java
@@ -2,16 +2,16 @@ package com.gagoo.thiscoding.domain.maria.user.infrastructure.impl;
 
 import com.gagoo.thiscoding.domain.maria.user.domain.JoinCode;
 import com.gagoo.thiscoding.domain.maria.user.infrastructure.JoinCodeRedis;
-import com.gagoo.thiscoding.domain.maria.user.infrastructure.jpa.JoinCodeRedisRepository;
 import com.gagoo.thiscoding.domain.maria.user.service.port.JoinCodeRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class JoinCodeRepositoryImpl implements JoinCodeRepository {
 
-    private final JoinCodeRedisRepository joinCodeRedisRepository;
+    private final RedisTemplate<String, String> redisTemplate;
 
     /**
      * 인증코드 레디스에 저장
@@ -19,7 +19,11 @@ public class JoinCodeRepositoryImpl implements JoinCodeRepository {
      */
     @Override
     public JoinCode save(JoinCode joinCode) {
-        return joinCodeRedisRepository.save(JoinCodeRedis.from(joinCode)).toModel();
-    }
+        String key = joinCode.getEmail() + ":code";
+        String value = joinCode.getCode();
 
+        redisTemplate.opsForValue().set(key, value);
+
+        return JoinCodeRedis.from(joinCode).toModel();
+    }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/jpa/JoinCodeRedisRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/jpa/JoinCodeRedisRepository.java
@@ -1,7 +1,0 @@
-package com.gagoo.thiscoding.domain.maria.user.infrastructure.jpa;
-
-import com.gagoo.thiscoding.domain.maria.user.infrastructure.JoinCodeRedis;
-import org.springframework.data.repository.CrudRepository;
-
-public interface JoinCodeRedisRepository extends CrudRepository<JoinCodeRedis, String> {
-}


### PR DESCRIPTION
crudeRepository를 상속받아 JPA처럼 데이터를 넣는 과정에서 원치않는 key-value 값으로 저장되어 redisTemplate을 활용하여 에러 해결

AuthController에서는 인가작업을 해야된다고 생각하여 인증하는 컨트롤러인 CertificationController로 클래스 이름 변경