### PR TITLE
fix: redisTemplate 사용으로 ttl 수동 설정

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/impl/JoinCodeRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/impl/JoinCodeRepositoryImpl.java
@@ -7,10 +7,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.concurrent.TimeUnit;
+
 @Repository
 @RequiredArgsConstructor
 public class JoinCodeRepositoryImpl implements JoinCodeRepository {
-
+    private static final String CODE = ":code";
     private final RedisTemplate<String, String> redisTemplate;
 
     /**
@@ -19,10 +21,10 @@ public class JoinCodeRepositoryImpl implements JoinCodeRepository {
      */
     @Override
     public JoinCode save(JoinCode joinCode) {
-        String key = joinCode.getEmail() + ":code";
+        String key = joinCode.getEmail() + CODE;
         String value = joinCode.getCode();
 
-        redisTemplate.opsForValue().set(key, value);
+        redisTemplate.opsForValue().set(key, value,  300, TimeUnit.SECONDS);
 
         return JoinCodeRedis.from(joinCode).toModel();
     }


### PR DESCRIPTION
redisTemplate을 사용하면 @RedisHash에 설정해도 적용이 안되어 인증 코드가 만료가 안되는 버그 발견. 
opsForValue()메서드에 ttl 설정하여 해결.

CODE 상수를 설정하여 전역에서 한 번에 관리