### PR TITLE
refactor: redis 키체인에 사용되는 :code 자체 클래스 생성

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/domain/contants/CodeKeyChain.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/domain/contants/CodeKeyChain.java
@@ -1,0 +1,5 @@
+package com.gagoo.thiscoding.domain.maria.user.domain.contants;
+
+public class CodeKeyChain {
+    public static final String CODE = ":code";
+}


### PR DESCRIPTION
같은 클래스에서 관리하면 단일 책임 원칙을 위반한다고 판단되어 생성