### PR TITLE
chore : spring security 의존성으로 인한 패키지 구조 변경

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/CustomUserDetails.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/CustomUserDetails.java
@@ -1,4 +1,4 @@
-package com.gagoo.thiscoding.domain.maria.user.domain.dto;
+package com.gagoo.thiscoding.domain.maria.user.infrastructure.security;
 
 import com.gagoo.thiscoding.domain.maria.user.domain.User;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/CustomUserDetailsService.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/CustomUserDetailsService.java
@@ -1,7 +1,6 @@
-package com.gagoo.thiscoding.domain.maria.user.service;
+package com.gagoo.thiscoding.domain.maria.user.infrastructure.security;
 
 import com.gagoo.thiscoding.domain.maria.user.domain.User;
-import com.gagoo.thiscoding.domain.maria.user.domain.dto.CustomUserDetails;
 import com.gagoo.thiscoding.domain.maria.user.infrastructure.exception.UserNotFoundException;
 import com.gagoo.thiscoding.domain.maria.user.service.port.UserRepository;
 import com.gagoo.thiscoding.global.exception.ErrorCode;

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/JWTUtil.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/JWTUtil.java
@@ -1,4 +1,4 @@
-package com.gagoo.thiscoding.global.config.security;
+package com.gagoo.thiscoding.domain.maria.user.infrastructure.security;
 
 import io.jsonwebtoken.Jwts;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/JwtLoginFilter.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/infrastructure/security/JwtLoginFilter.java
@@ -1,10 +1,8 @@
-package com.gagoo.thiscoding.global.config.security;
+package com.gagoo.thiscoding.domain.maria.user.infrastructure.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gagoo.thiscoding.domain.maria.user.domain.dto.CustomUserDetails;
 import com.gagoo.thiscoding.domain.maria.user.domain.dto.UserLogin;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/com/gagoo/thiscoding/global/config/SecurityConfig.java
+++ b/src/main/java/com/gagoo/thiscoding/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
-package com.gagoo.thiscoding.global.config.security;
+package com.gagoo.thiscoding.global.config;
 
+import com.gagoo.thiscoding.domain.maria.user.infrastructure.security.JWTUtil;
+import com.gagoo.thiscoding.domain.maria.user.infrastructure.security.JwtLoginFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;


### PR DESCRIPTION
Spring Security는 전역으로 쓰는 콘피그 파일이기 때문에 global 패키지에 유지하지만그 외 클래스는 유저의 인증 인가와 관련되어 있고 security와 의존성이 있기 때문에 외부 의존성을 관리하는 패키지인 infrastructure로 이동