### PR TITLE
feat : qna 작성, 전체조회

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/BaseTimeDocument.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/BaseTimeDocument.java
@@ -15,5 +15,5 @@ public class BaseTimeDocument {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Field
-    private LocalDateTime createDate;
+    public LocalDateTime createDate;
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
@@ -1,21 +1,37 @@
 package com.gagoo.thiscoding.domain.mongo.board.controller;
 
+import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
 import com.gagoo.thiscoding.domain.mongo.board.controller.port.BoardService;
 import com.gagoo.thiscoding.domain.mongo.board.controller.response.SearchResponse;
+import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
+import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaList;
+import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.paging.dto.PageResponse;
+import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import static org.springframework.http.HttpStatus.*;
+
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/qna")
 public class BoardReadController {
+
     private final BoardService boardService;
+
+    @GetMapping
+    @AuthorizationRequired(value = {Role.USER, Role.ADMIN}, status = OK)
+    public ResponseEntity<CustomPageDto<Page<QnaList>>> getAll(Pageable pageable) {
+        return ResponseEntity.ok(boardService.findAll(pageable));
+    }
 
     @GetMapping("/search")
     public ResponseEntity<PageResponse<SearchResponse>> search(@RequestParam String keyword, @RequestParam(defaultValue = "1") int page) {

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
@@ -7,7 +7,6 @@ import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
 import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaList;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.paging.dto.PageResponse;
-import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +27,6 @@ public class BoardReadController {
     private final BoardService boardService;
 
     @GetMapping
-    @AuthorizationRequired(value = {Role.USER, Role.ADMIN}, status = OK)
     public ResponseEntity<CustomPageDto<Page<QnaList>>> getAll(Pageable pageable) {
         return ResponseEntity.ok(boardService.findAll(pageable));
     }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardWriteController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardWriteController.java
@@ -5,7 +5,6 @@ import com.gagoo.thiscoding.domain.mongo.board.controller.port.BoardService;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.BoardCreate;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardWriteController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardWriteController.java
@@ -1,13 +1,18 @@
 package com.gagoo.thiscoding.domain.mongo.board.controller;
 
+import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
 import com.gagoo.thiscoding.domain.mongo.board.controller.port.BoardService;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.BoardCreate;
+import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequestMapping("/api/qna")
@@ -17,6 +22,7 @@ public class BoardWriteController {
     private final BoardService boardService;
 
     @PostMapping
+    @AuthorizationRequired(value = {Role.USER, Role.ADMIN}, status = OK)
     public ResponseEntity<Void> create(@RequestBody BoardCreate boardCreate) {
         boardService.create(boardCreate);
 

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/port/BoardService.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/port/BoardService.java
@@ -3,6 +3,8 @@ package com.gagoo.thiscoding.domain.mongo.board.controller.port;
 import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.BoardCreate;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.Search;
+import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaList;
+import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +12,5 @@ public interface BoardService {
     Board create(BoardCreate boardCreate);
     Page<Search> searchByKeyword(String keyword, int page);
     Page<Board> getMyPagePostQnA(Pageable pageable);
+    CustomPageDto<Page<QnaList>> findAll(Pageable pageable);
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/domain/Board.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/domain/Board.java
@@ -1,5 +1,6 @@
 package com.gagoo.thiscoding.domain.mongo.board.domain;
 
+import com.gagoo.thiscoding.domain.maria.user.domain.User;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.BoardCreate;
 import com.gagoo.thiscoding.domain.mongo.board.infrastructure.BoardDocument;
 import lombok.Builder;
@@ -8,9 +9,12 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 public class Board {
     private String id;
     private Long userId;
+    private String nickname;
+    private String profileImg;
     private String title;
     private String content;
     private String language;
@@ -20,26 +24,13 @@ public class Board {
     private Long answerCount;
     private boolean isBlind;
     private boolean isSelected;
+    private LocalDateTime createDate;
 
-    @Builder
-    public Board(String id, Long userId,String title,String content,String language,Long parentId,Long likeCount,Long viewCount
-            ,Long answerCount,Boolean isBlind,Boolean isSelected,LocalDateTime createDate) {
-        this.id = id;
-        this.userId = userId;
-        this.title = title;
-        this.content = content;
-        this.language = language;
-        this.parentId = parentId;
-        this.likeCount = likeCount;
-        this.viewCount = viewCount;
-        this.answerCount = answerCount;
-        this.isBlind = isBlind;
-        this.isSelected = isSelected;
-    }
-
-    public static Board create(BoardCreate boardCreate) {
+    public static Board create(User user, BoardCreate boardCreate) {
         return Board.builder()
-                .userId(boardCreate.getUserId())
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImg(user.getImageUrl())
                 .title(boardCreate.getTitle())
                 .content(boardCreate.getContent())
                 .language(boardCreate.getLanguage())

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/domain/dto/BoardCreate.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/domain/dto/BoardCreate.java
@@ -8,15 +8,13 @@ import lombok.Getter;
 @Getter
 public class BoardCreate {
 
-    @NotBlank private final Long userId;
     @NotBlank private final String title;
     @NotBlank private final String content;
     @NotBlank private final String language;
     private final Long parentId;
 
     @Builder
-    public BoardCreate(Long userId, String title, String content, String language, Long parentId) {
-        this.userId = userId;
+    public BoardCreate(String title, String content, String language, Long parentId) {
         this.title = title;
         this.content = content;
         this.language = language;

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/BoardDocument.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/BoardDocument.java
@@ -3,11 +3,13 @@ package com.gagoo.thiscoding.domain.mongo.board.infrastructure;
 import com.gagoo.thiscoding.domain.mongo.BaseTimeDocument;
 import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
 import lombok.Getter;
+import lombok.ToString;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Getter
+@ToString
 @Document(collection = "qna")
 public class BoardDocument extends BaseTimeDocument {
 
@@ -17,6 +19,10 @@ public class BoardDocument extends BaseTimeDocument {
     @Field(name = "users_id")
     private Long userId;
 
+    private String nickname;
+
+    private String profileImg;
+
     private String title;
 
     private String content;
@@ -25,10 +31,13 @@ public class BoardDocument extends BaseTimeDocument {
 
     private Long parentId;
 
+    @Field(name = "like_count")
     private Long likeCount;
 
+    @Field(name = "view_count")
     private Long viewCount;
 
+    @Field(name = "answer_count")
     private Long answerCount;
 
     private boolean isBlind;
@@ -39,6 +48,8 @@ public class BoardDocument extends BaseTimeDocument {
         BoardDocument boardDocument = new BoardDocument();
         boardDocument.id = board.getId();
         boardDocument.userId = board.getUserId();
+        boardDocument.nickname = board.getNickname();
+        boardDocument.profileImg = board.getProfileImg();
         boardDocument.title = board.getTitle();
         boardDocument.content = board.getContent();
         boardDocument.language = board.getLanguage();
@@ -56,6 +67,8 @@ public class BoardDocument extends BaseTimeDocument {
         return Board.builder()
                 .id(id)
                 .userId(userId)
+                .nickname(nickname)
+                .profileImg(profileImg)
                 .title(title)
                 .content(content)
                 .language(language)
@@ -65,6 +78,7 @@ public class BoardDocument extends BaseTimeDocument {
                 .answerCount(answerCount)
                 .isBlind(isBlind)
                 .isSelected(isSelected)
+                .createDate(createDate)
                 .build();
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardRepositoryImpl.java
@@ -32,6 +32,11 @@ private final BoardMongoRepository boardMongoRepository;
     }
 
     @Override
+    public Page<Board> findByParentIdIsNull(Pageable pageable) {
+        return boardMongoRepository.findByParentIdIsNullOrderByCreateDateDesc(pageable).map(BoardDocument::toModel);
+    }
+
+    @Override
     public boolean existsById(String qnaId) {
         return boardMongoRepository.existsById(qnaId);
     }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/mongo/BoardMongoRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/mongo/BoardMongoRepository.java
@@ -7,5 +7,6 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 public interface BoardMongoRepository extends MongoRepository<BoardDocument, String> {
     Page<BoardDocument> findByUserId(Long userId, Pageable pageable);
     Page<BoardDocument> findByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
+    Page<BoardDocument> findByParentIdIsNullOrderByCreateDateDesc(Pageable pageable);
 }
 

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
@@ -7,10 +7,12 @@ import com.gagoo.thiscoding.domain.mongo.board.controller.port.BoardService;
 import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.BoardCreate;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.Search;
+import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaList;
 import com.gagoo.thiscoding.domain.mongo.board.service.port.BoardRepository;
 import com.gagoo.thiscoding.global.exception.ErrorCode;
 import com.gagoo.thiscoding.global.paging.PageSize;
 import com.gagoo.thiscoding.global.paging.PagingProcessor;
+import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.security.SecurityUtils;
 import com.gagoo.thiscoding.global.security.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +32,9 @@ public class BoardServiceImpl implements BoardService {
      */
     @Override
     public Board create(BoardCreate boardCreate) {
-        Board board = Board.create(boardCreate);
+        User currentUser = getByEmail(SecurityUtils.getUserEmail());
+
+        Board board = Board.create(currentUser, boardCreate);
 
         return boardRepository.save(board);
     }
@@ -51,6 +55,15 @@ public class BoardServiceImpl implements BoardService {
     public Page<Board> getMyPagePostQnA(Pageable pageable) {
         User currentUser = getByEmail(SecurityUtils.getUserEmail());
         return boardRepository.findByUserId(currentUser.getId(), pageable);
+    }
+
+    @Override
+    public CustomPageDto<Page<QnaList>> findAll(Pageable pageable) {
+        Page<QnaList> qnaListPage = boardRepository.findByParentIdIsNull(pageable).map(
+                qna -> QnaList.from(qna)
+        );
+
+        return new CustomPageDto(qnaListPage);
     }
 
     public User getByEmail(String email) {

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/dto/QnaList.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/dto/QnaList.java
@@ -1,0 +1,52 @@
+package com.gagoo.thiscoding.domain.mongo.board.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class QnaList {
+
+    @JsonProperty
+    private final String language;
+    @JsonProperty
+    private final String title;
+    @JsonProperty
+    private final String content;
+    @JsonProperty
+    private final String nickname;
+    @JsonProperty
+    private final Long viewCount;
+    @JsonProperty
+    private final Long answerCount;
+    @JsonProperty
+    private final LocalDateTime createDate;
+
+    @Builder
+    public QnaList(String language, String title, String content, String nickname, Long viewCount, Long answerCount, LocalDateTime createDate) {
+        this.language = language;
+        this.title = title;
+        this.content = content;
+        this.nickname = nickname;
+        this.viewCount = viewCount;
+        this.answerCount = answerCount;
+        this.createDate = createDate;
+    }
+
+    public static QnaList from(Board board) {
+        return QnaList.builder()
+                .language(board.getLanguage())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .nickname(board.getNickname())
+                .viewCount(board.getViewCount())
+                .answerCount(board.getAnswerCount())
+                .createDate(board.getCreateDate())
+                .build();
+    }
+}

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/port/BoardRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/port/BoardRepository.java
@@ -2,12 +2,14 @@ package com.gagoo.thiscoding.domain.mongo.board.service.port;
 
 import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.Search;
+import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaList;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardRepository {
     Page<Board> findByUserId(Long userId, Pageable pageable);
     Page<Search> findByTitleOrContent(String title, String content, Pageable pageable);
+    Page<Board> findByParentIdIsNull(Pageable pageable);
     Board save(Board board);
     boolean existsById(String qnaId);
 }


### PR DESCRIPTION
qna 작성할 때 기존 로그인 구현 전 필요했던 dto 필드의 userId 삭제 -> 시큐리티 컨텍스트 홀더에서 뽑아 쓰도록 변경

qna 전체조회 page 당 10개의 데이터씩 가져오도록 구현