### PR TITLE
feat: CodeRoom - Custom Exception 및 ErrorCode 추가

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/service/exception/AlreadyJoinedCodeRoomException.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/service/exception/AlreadyJoinedCodeRoomException.java
@@ -1,0 +1,10 @@
+package com.gagoo.thiscoding.domain.maria.coderoom.service.exception;
+
+import com.gagoo.thiscoding.global.exception.ErrorCode;
+import com.gagoo.thiscoding.global.exception.GlobalException;
+
+public class AlreadyJoinedCodeRoomException extends GlobalException {
+    public AlreadyJoinedCodeRoomException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/gagoo/thiscoding/global/exception/ErrorCode.java
+++ b/src/main/java/com/gagoo/thiscoding/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "페이지가 유효하지 않습니다."),
     SOCIAL_ACCOUNT_CONFLICT(HttpStatus.CONFLICT, "이미 해당 이메일로 가입된 아이디가 있습니다."),
     ALREADY_CREATE_EMAIL(HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+    ALREADY_CODE_ROOM(HttpStatus.CONFLICT, "이미 참여중인 코드방입니다."),
     ALREADY_FRIEND(HttpStatus.CONFLICT, "이미 친구목록에 존재하는 회원입니다."),
     ALREADY_USER_CODE_ROOM(HttpStatus.CONFLICT, "이미 참여중인 코드방입니다."),
     EXIST_MEMBER_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),


### PR DESCRIPTION
**변경사항**
--

- `AlreadyJoinedCodeRoomException` 추가
     - 사용자가 이미 참여 중인 `CodeRoom`에 참여를 시도할 경우 발생시키는 커스텀 예외

- `ErrorCode` - `ALREADY_CODE_ROOM` 추가
     - “이미 참여한 코드룸” 상황에 대한 에러 코드
