### PR TITLE
feat: Alarm - delete, exist, getById 메서드 추가

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/infrastructure/impl/AlarmRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/infrastructure/impl/AlarmRepositoryImpl.java
@@ -1,12 +1,17 @@
 package com.gagoo.thiscoding.domain.maria.alarm.infrastructure.impl;
 
 import com.gagoo.thiscoding.domain.maria.alarm.domain.Alarm;
+import com.gagoo.thiscoding.domain.maria.alarm.domain.AlarmType;
 import com.gagoo.thiscoding.domain.maria.alarm.infrastructure.AlarmEntity;
 import com.gagoo.thiscoding.domain.maria.alarm.infrastructure.jpa.AlarmJpaRepository;
+import com.gagoo.thiscoding.domain.maria.alarm.service.exception.AlarmNotFoundException;
 import com.gagoo.thiscoding.domain.maria.alarm.service.port.AlarmRepository;
+import com.gagoo.thiscoding.global.exception.ErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Repository
 @RequiredArgsConstructor
@@ -15,8 +20,10 @@ public class AlarmRepositoryImpl implements AlarmRepository {
     private final AlarmJpaRepository alarmJpaRepository;
 
     @Override
-    public Alarm save(Alarm alarm) {
-        return alarmJpaRepository.save(AlarmEntity.from(alarm)).toModel();
+    public Alarm getById(Long alarmId) {
+        return alarmJpaRepository.findById(alarmId).map(AlarmEntity::toModel)
+            .orElseThrow(() -> new AlarmNotFoundException(
+                ErrorCode.ALARM_NOT_FOUND));
     }
 
     @Override
@@ -25,7 +32,18 @@ public class AlarmRepositoryImpl implements AlarmRepository {
     }
 
     @Override
-    public void delete(Alarm alarm) {
-        alarmJpaRepository.delete(AlarmEntity.from(alarm));
+    public Alarm save(Alarm alarm) {
+        return alarmJpaRepository.save(AlarmEntity.from(alarm)).toModel();
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Override
+    public void deleteById(Long alarmId) {
+        alarmJpaRepository.deleteById(alarmId);
+    }
+
+    @Override
+    public boolean existsByIdAndTypeAndTargetId(Long alarmId, AlarmType alarmType, Long targetId) {
+        return alarmJpaRepository.existsByIdAndTypeAndTargetId(alarmId, alarmType, targetId);
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/infrastructure/impl/AlarmRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/infrastructure/impl/AlarmRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.gagoo.thiscoding.domain.maria.alarm.infrastructure.impl;
 
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
 import com.gagoo.thiscoding.domain.maria.alarm.domain.Alarm;
 import com.gagoo.thiscoding.domain.maria.alarm.domain.AlarmType;
 import com.gagoo.thiscoding.domain.maria.alarm.infrastructure.AlarmEntity;
@@ -10,7 +12,6 @@ import com.gagoo.thiscoding.global.exception.ErrorCode;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
@@ -36,7 +37,7 @@ public class AlarmRepositoryImpl implements AlarmRepository {
         return alarmJpaRepository.save(AlarmEntity.from(alarm)).toModel();
     }
 
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @Transactional(propagation = REQUIRES_NEW)
     @Override
     public void deleteById(Long alarmId) {
         alarmJpaRepository.deleteById(alarmId);

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/infrastructure/jpa/AlarmJpaRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/infrastructure/jpa/AlarmJpaRepository.java
@@ -1,7 +1,9 @@
 package com.gagoo.thiscoding.domain.maria.alarm.infrastructure.jpa;
 
+import com.gagoo.thiscoding.domain.maria.alarm.domain.AlarmType;
 import com.gagoo.thiscoding.domain.maria.alarm.infrastructure.AlarmEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AlarmJpaRepository extends JpaRepository<AlarmEntity, Long> {
+    boolean existsByIdAndTypeAndTargetId(Long alarmId, AlarmType type, Long targetId);
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/service/port/AlarmRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/alarm/service/port/AlarmRepository.java
@@ -1,11 +1,14 @@
 package com.gagoo.thiscoding.domain.maria.alarm.service.port;
 
 import com.gagoo.thiscoding.domain.maria.alarm.domain.Alarm;
+import com.gagoo.thiscoding.domain.maria.alarm.domain.AlarmType;
 import java.util.Optional;
 
 public interface AlarmRepository {
 
+    Alarm getById(Long alarmId);
     Optional<Alarm> findById(Long id);
     Alarm save(Alarm alarm);
-    void delete(Alarm alarm);
+    void deleteById(Long alarmId);
+    boolean existsByIdAndTypeAndTargetId(Long alarmId, AlarmType alarmType, Long targetId);
 }


### PR DESCRIPTION
**변경사항**
--
- getById 메서드 추가
    - 다른 도메인에서 자주 사용되는 메서드로, `Repository`에서 예외처리 하여 사용할 수 있도록 구현

- deleteById 메서드 추가
     - `CodeRoom` 수락/거절 시, 트랜잭션 없이 알람을 삭제하기 위해 
     `@Transactional(propagation = REQUIRES_NEW)`로 설정

- existsByIdAndTypeAndTargetId 메서드 추가
    - `Target`의 `Type`이 유효한지 검증하도록 구현