### PR TITLE
refactor : 답변조회시 답변에 달린 댓글 갯수 추가

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/reply/domain/dto/ReplyCreate.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/reply/domain/dto/ReplyCreate.java
@@ -1,6 +1,5 @@
 package com.gagoo.thiscoding.domain.maria.reply.domain.dto;
 
-import com.gagoo.thiscoding.domain.maria.reply.infrastructure.ReplyEntity;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/reply/infrastructure/impl/ReplyCustomRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/reply/infrastructure/impl/ReplyCustomRepository.java
@@ -1,6 +1,7 @@
 package com.gagoo.thiscoding.domain.maria.reply.infrastructure.impl;
 
 import com.gagoo.thiscoding.domain.maria.reply.domain.Reply;
+import com.gagoo.thiscoding.domain.maria.reply.infrastructure.QReplyEntity;
 import com.gagoo.thiscoding.domain.maria.reply.service.dto.ReplyList;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -13,9 +14,11 @@ import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.gagoo.thiscoding.domain.maria.reply.infrastructure.QReplyEntity.*;
 import static com.gagoo.thiscoding.domain.maria.user.infrastructure.QUserEntity.*;
+import static com.querydsl.core.group.GroupBy.groupBy;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,6 +26,9 @@ public class ReplyCustomRepository {
 
     private final JPAQueryFactory query;
 
+    /**
+     * qna에 달린 댓글 조회
+     */
     public Page<ReplyList> findByQnaId(String qnaId, Pageable pageable) {
 
         List<ReplyList> results = query.select(Projections.constructor(ReplyList.class,
@@ -74,7 +80,6 @@ public class ReplyCustomRepository {
 
     return PageableExecutionUtils.getPage(results,pageable, countQuery::fetchOne);
     }
-
     public void deleteRepliesAndParent(Reply reply) {
         query.delete(replyEntity)
             .where(replyEntity.parent.id.eq(reply.getId())
@@ -96,6 +101,7 @@ public class ReplyCustomRepository {
     private  BooleanExpression parentIdIsNotNull(){
         return replyEntity.parent.id.isNotNull();
     }
+
     private  BooleanExpression parentIdEq(Long parentId){
         return replyEntity.parent.id.eq(parentId);
     }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/reply/infrastructure/impl/ReplyRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/reply/infrastructure/impl/ReplyRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.gagoo.thiscoding.domain.maria.reply.infrastructure.ReplyEntity;
 import com.gagoo.thiscoding.domain.maria.reply.infrastructure.jpa.ReplyJpaRepository;
 import com.gagoo.thiscoding.domain.maria.reply.service.dto.ReplyList;
 import com.gagoo.thiscoding.domain.maria.reply.service.port.ReplyRepository;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/reply/service/ReplyServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/reply/service/ReplyServiceImpl.java
@@ -52,6 +52,7 @@ public class ReplyServiceImpl implements ReplyService {
 
         Reply reply = Reply.create(currentUser, qnaId, replyCreate, parentComment);
 
+        boardRepository.incrementReplyCount(qnaId);
         return replyRepository.save(reply);
     }
 
@@ -72,6 +73,7 @@ public class ReplyServiceImpl implements ReplyService {
      * 댓글 아이디로 대댓글 조회
      */
     @Override
+    @Transactional(readOnly = true)
     public CustomPageDto<ReplyList> getReplies(String qnaId, Long parentId, Pageable pageable) {
         validateReplyId(parentId);
 

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/reply/service/port/ReplyRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/reply/service/port/ReplyRepository.java
@@ -8,11 +8,11 @@ import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
 public interface ReplyRepository {
-    Reply save(Reply reply);
     Optional<Reply> findById(Long id);
-    Page<ReplyList> findByQnaId(String qnaId, Pageable pageable);
-    Long countByQnaId(String qnaId);
+    Reply save(Reply reply);
+    Long countByQnaId(String qnaIds);
     boolean existsById(Long parentId);
     void delete(Reply reply);
     Page<ReplyList> findRepliesByParentId(String qnaId, Long parentId, Pageable pageable);
+    Page<ReplyList> findByQnaId(String qnaId, Pageable pageable);
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/port/BoardService.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/port/BoardService.java
@@ -18,7 +18,7 @@ import java.util.List;
 public interface BoardService {
     Board create(BoardCreate boardCreate);
     QnaDetail get(String qnaId, HttpServletRequest request, HttpServletResponse response);
-    List<Board> writeAnswer(String qnaId, BoardAnswer boardAnswer);
+    Board writeAnswer(String qnaId, BoardAnswer boardAnswer);
     Page<Search> searchByKeyword(String keyword, Pageable pageable);
     Page<Board> getMyPagePostQnA(Pageable pageable);
     CustomPageDto<QnaList> findAll(Pageable pageable);

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/response/AnswerListResponse.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/response/AnswerListResponse.java
@@ -9,20 +9,22 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class AnswerListResponse {
+    private final String answerId;
     private final String nickname;
     private final String profileImage;
     private final LocalDateTime createDate;
     private final String content;
-    private final Long answerCount;
+    private final Long replyCount;
     private final Long likeCount;
 
     public static AnswerListResponse from(AnswerList answer) {
         return AnswerListResponse.builder()
+                .answerId(answer.answerId())
                 .nickname(answer.nickname())
                 .profileImage(answer.profileImage())
                 .createDate(answer.createDate())
                 .content(answer.content())
-                .answerCount(answer.answerCount())
+                .replyCount(answer.replyCount())
                 .likeCount(answer.likeCount())
                 .build();
     }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/domain/Board.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/domain/Board.java
@@ -21,6 +21,7 @@ public class Board {
     private Long likeCount;
     private Long viewCount;
     private Long answerCount;
+    private Long replyCount;
     private boolean isBlind;
     private boolean isSelected;
     private LocalDateTime createDate;
@@ -40,6 +41,7 @@ public class Board {
                 .likeCount(0L)
                 .viewCount(0L)
                 .answerCount(0L)
+                .replyCount(0L)
                 .isBlind(false)
                 .build();
     }
@@ -55,15 +57,9 @@ public class Board {
                 .content(content)
                 .parentId(parentId)
                 .likeCount(0L)
+                .replyCount(0L)
                 .isBlind(false)
                 .isSelected(false)
                 .build();
-    }
-
-    /**
-     * 답변이 작성되면 부모 게시물의 답변 갯수 증가
-     */
-    public void increaseAnswerCount() {
-        this.answerCount++;
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/BoardDocument.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/BoardDocument.java
@@ -38,6 +38,9 @@ public class BoardDocument extends BaseTimeDocument {
     @Field(name = "answer_count")
     private Long answerCount;
 
+    @Field(name = "reply_count")
+    private Long replyCount;
+
     private boolean isBlind;
 
     private boolean isSelected;
@@ -55,6 +58,7 @@ public class BoardDocument extends BaseTimeDocument {
         boardDocument.likeCount = board.getLikeCount();
         boardDocument.viewCount = board.getViewCount();
         boardDocument.answerCount = board.getAnswerCount();
+        boardDocument.replyCount = board.getReplyCount();
         boardDocument.isBlind = board.isBlind();
         boardDocument.isSelected = board.isSelected();
 
@@ -74,6 +78,7 @@ public class BoardDocument extends BaseTimeDocument {
                 .likeCount(likeCount)
                 .viewCount(viewCount)
                 .answerCount(answerCount)
+                .replyCount(replyCount)
                 .isBlind(isBlind)
                 .isSelected(isSelected)
                 .createDate(createDate)

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardCustomRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardCustomRepository.java
@@ -57,6 +57,9 @@ public class BoardCustomRepository {
         return results;
     }
 
+    /**
+     * 조회수 1 증가
+     */
     public void incrementViewCount(String qnaId) {
         Query query = new Query(Criteria.where("_id").is(qnaId));
         Update update = new Update().inc("viewCount", 1);
@@ -64,4 +67,23 @@ public class BoardCustomRepository {
         mongoTemplate.updateFirst(query, update, BoardDocument.class);
     }
 
+    /**
+     * 답변 갯수 1 증가
+     */
+    public void incrementAnswerCount(String parentQnaId) {
+        Query query = new Query(Criteria.where("id").is(parentQnaId));
+        Update update = new Update().inc("answerCount", 1);
+
+        mongoTemplate.updateFirst(query, update, BoardDocument.class);
+    }
+
+    /**
+     * 댓글 갯수 1 증가
+     */
+    public void incrementReplyCount(String parentQnaId) {
+        Query query = new Query(Criteria.where("id").is(parentQnaId));
+        Update update = new Update().inc("replyCount", 1);
+
+        mongoTemplate.updateFirst(query, update, BoardDocument.class);
+    }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardRepositoryImpl.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -30,11 +29,33 @@ public class BoardRepositoryImpl implements BoardRepository {
         );
     }
 
+    /**
+     * 조회수 증가
+     */
     @Override
     public void incrementViewCount(String qnaId) {
         boardCustomRepository.incrementViewCount(qnaId);
     }
 
+    /**
+     * 댓글 갯수 증가
+     */
+    @Override
+    public void incrementReplyCount(String qnaId) {
+        boardCustomRepository.incrementReplyCount(qnaId);
+    }
+
+    /**
+     * 답변 갯수 증가
+     */
+    @Override
+    public void incrementAnswerCount(String parentQnaId) {
+        boardCustomRepository.incrementAnswerCount(parentQnaId);
+    }
+
+    /**
+     * 채택 많이 된 상위 10명 조회
+     */
     @Override
     public List<Long> getTop10Users() {
         return boardCustomRepository.getTop10Users();
@@ -68,18 +89,6 @@ public class BoardRepositoryImpl implements BoardRepository {
     @Override
     public Board save(Board board) {
         return boardMongoRepository.save(BoardDocument.from(board)).toModel();
-    }
-
-    @Override
-    public List<Board> saveAll(List<Board> boards) {
-        return boardMongoRepository.saveAll(
-                        boards.stream()
-                                .map(BoardDocument::from)
-                                .collect(Collectors.toList())
-                )
-                .stream()
-                .map(BoardDocument::toModel)
-                .collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
@@ -11,10 +11,12 @@ import com.gagoo.thiscoding.domain.mongo.board.domain.dto.Search;
 import com.gagoo.thiscoding.domain.mongo.board.service.dto.AnswerList;
 import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaDetail;
 import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaList;
+import com.gagoo.thiscoding.domain.mongo.board.service.exception.QnaNotFoundException;
 import com.gagoo.thiscoding.domain.mongo.board.service.port.BoardRepository;
 import com.gagoo.thiscoding.domain.mongo.board.service.port.BoardViewService;
 import com.gagoo.thiscoding.global.common.util.HttpServletUtils;
 import com.gagoo.thiscoding.global.common.uuid.service.port.UuidHolder;
+import com.gagoo.thiscoding.global.exception.ErrorCode;
 import com.gagoo.thiscoding.global.paging.PageSize;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.domain.auth.service.port.SecurityUtils;
@@ -63,15 +65,14 @@ public class BoardServiceImpl implements BoardService {
      * qna 답변 작성
      */
     @Override
-    public List<Board> writeAnswer(String parentQnaId, BoardAnswer boardAnswer) {
+    public Board writeAnswer(String parentQnaId, BoardAnswer boardAnswer) {
         User currentUser = getCurrentUser();
-
-        Board parentBoard = boardRepository.getById(parentQnaId);
-        parentBoard.increaseAnswerCount();
+        validateParentQnaExists(parentQnaId);
 
         Board answer = Board.writeAnswer(currentUser, parentQnaId, boardAnswer.content());
+        boardRepository.incrementAnswerCount(parentQnaId);
 
-        return boardRepository.saveAll(List.of(answer, parentBoard));
+        return boardRepository.save(answer);
     }
 
     /**
@@ -88,6 +89,7 @@ public class BoardServiceImpl implements BoardService {
 
         return QnaDetail.from(qnaDetail, replyCount);
     }
+
     /**
      * QnA 제목 + 내용 검색
      */
@@ -96,7 +98,6 @@ public class BoardServiceImpl implements BoardService {
         Pageable customPageable = PageRequest.of(pageable.getPageNumber(), PageSize.QNA);
         return boardRepository.findByTitleOrContent(keyword, keyword, customPageable);
     }
-
     /**
      * 마이페이지 내가 작성한 Qna 조회
      */
@@ -145,6 +146,15 @@ public class BoardServiceImpl implements BoardService {
             httpServletUtils.addCookie(response, "visitorId", visitorId, 60L * 60 * 24 * 365);
 
             return visitorId;
+        }
+    }
+
+    /**
+     * 부모 게시물이 있는지 확인
+     */
+    private void validateParentQnaExists(String parentQnaId) {
+        if (!boardRepository.existsById(parentQnaId)) {
+            throw new QnaNotFoundException(ErrorCode.QNA_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/dto/AnswerList.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/dto/AnswerList.java
@@ -4,7 +4,7 @@ import com.gagoo.thiscoding.domain.mongo.board.domain.Board;
 
 import java.time.LocalDateTime;
 
-public record AnswerList(String qnaId, String nickname, String profileImage, String content, Long likeCount, Long answerCount, LocalDateTime createDate) {
+public record AnswerList(String answerId, String nickname, String profileImage, String content, Long likeCount, Long replyCount, LocalDateTime createDate) {
 
     public static AnswerList from(Board board) {
         return new AnswerList(
@@ -13,7 +13,7 @@ public record AnswerList(String qnaId, String nickname, String profileImage, Str
                 board.getProfileImg(),
                 board.getContent(),
                 board.getLikeCount(),
-                board.getAnswerCount(),
+                board.getReplyCount(),
                 board.getCreateDate()
         );
     }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/port/BoardRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/port/BoardRepository.java
@@ -15,7 +15,8 @@ public interface BoardRepository {
     Page<Board> findByUserId(Long userId, Pageable pageable);
     Page<Search> findByTitleOrContent(String title, String content, Pageable pageable);
     Page<Board> findAnswerByQnaId(String qnaId, Pageable pageable);
-    List<Board> saveAll(List<Board> boardList);
     boolean existsById(String qnaId);
     void incrementViewCount(String qnaId);
+    void incrementAnswerCount(String parentQnaId);
+    void incrementReplyCount(String qnaId);
 }

--- a/src/test/java/com/gagoo/thiscoding/domain/mock/FakeBoardRepository.java
+++ b/src/test/java/com/gagoo/thiscoding/domain/mock/FakeBoardRepository.java
@@ -92,17 +92,22 @@ public class FakeBoardRepository implements BoardRepository {
     }
 
     @Override
-    public List<Board> saveAll(List<Board> boardList) {
-        return null;
-    }
-
-    @Override
     public boolean existsById(String qnaId) {
         return data.stream().anyMatch(board -> board.getId().equals(qnaId));
     }
 
     @Override
     public void incrementViewCount(String boardId) {
+
+    }
+
+    @Override
+    public void incrementAnswerCount(String parentQnaId) {
+
+    }
+
+    @Override
+    public void incrementReplyCount(String qnaId) {
 
     }
 

--- a/src/test/java/com/gagoo/thiscoding/domain/mock/FakeReplyRepository.java
+++ b/src/test/java/com/gagoo/thiscoding/domain/mock/FakeReplyRepository.java
@@ -8,10 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class FakeReplyRepository implements ReplyRepository {
@@ -83,7 +80,6 @@ public class FakeReplyRepository implements ReplyRepository {
                 () -> (long) findAllReply.size()
         );
     }
-
 
     @Override
     public Long countByQnaId(String qnaId) {


### PR DESCRIPTION
답변에 대한 댓글 갯수를 가져올 때 NoSQL과 RDB간의 Join이 불가능으로 in절 사용시 답변 조회가 많으면 많을 수록 비교 대상이 많아져 성능 이슈가 생기기 때문에 likeCount를 Board에 추가