### PR TITLE
refactor: ParticipationController, ParticipationService 관련 메서드, 반환 값 변경

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/ParticipationController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/ParticipationController.java
@@ -9,6 +9,7 @@ import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,20 +35,18 @@ public class ParticipationController {
     // 참여 중인 코드방 입/퇴장
     @PatchMapping("/{id}/access")
     @AuthorizationRequired(value = Role.USER, status = OK)
-    public ResponseEntity<?> accessParticipation(@PathVariable Long id) {
-        participationService.accessUserCodeRoom(id);
+    public ResponseEntity<Boolean> accessParticipation(@PathVariable Long id) {
         return ResponseEntity
-                .ok()
-                .body("코드방 입/퇴장 성공");
+                .status(HttpStatus.OK)
+                .body(participationService.accessUserCodeRoom(id));
     }
 
     // 참여 중인 코드방 탈퇴
     @DeleteMapping("/{id}/leave")
     @AuthorizationRequired(value = Role.USER, status = OK)
-    public ResponseEntity<?> leaveParticipation(@PathVariable Long id) {
-        participationService.leaveUserCodeRoom(id);
+    public ResponseEntity<Boolean> leaveParticipation(@PathVariable Long id) {
         return ResponseEntity
-                .ok()
-                .body("코드방 탈퇴 성공");
+                .status(HttpStatus.OK)
+                .body(participationService.leaveUserCodeRoom(id));
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/port/ParticipationService.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/port/ParticipationService.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 public interface ParticipationService {
     Page<ParticipatingCodeRoomResponse> getParticipations(Pageable pageable);
 
-    void accessUserCodeRoom(Long id);
+    boolean accessUserCodeRoom(Long id);
 
-    void leaveUserCodeRoom(Long id);
+    boolean leaveUserCodeRoom(Long id);
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/infrastructure/Impl/CodeRoomCustomRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/infrastructure/Impl/CodeRoomCustomRepositoryImpl.java
@@ -90,15 +90,14 @@ public class CodeRoomCustomRepositoryImpl implements CodeRoomCustomRepository {
                 .fetch();
     }
 
-    public Page<UserCodeRoom> findAllByEmailAndIsActivatedTrue(String email, Pageable pageable) {
-        BooleanExpression emailCondition = userEntity.email.eq(email);
-        BooleanExpression isActivatedCondition = userCodeRoomEntity.isActivated.isTrue();
+    public Page<UserCodeRoom> findAllUserCodeRoomByUser(User user, Pageable pageable) {
+        BooleanExpression userIdCondition = userEntity.id.eq(user.getId());
 
         List<UserCodeRoom> result = queryFactory
                 .selectFrom(userCodeRoomEntity)
                 .join(userCodeRoomEntity.codeRoom, codeRoomEntity).fetchJoin()
                 .join(userCodeRoomEntity.user, userEntity).fetchJoin()
-                .where(emailCondition.and(isActivatedCondition))
+                .where(userIdCondition)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch()
@@ -111,7 +110,7 @@ public class CodeRoomCustomRepositoryImpl implements CodeRoomCustomRepository {
                 .from(userCodeRoomEntity)
                 .join(userCodeRoomEntity.codeRoom, codeRoomEntity)
                 .join(userCodeRoomEntity.user, userEntity)
-                .where(emailCondition.and(isActivatedCondition));
+                .where(userIdCondition);
 
         return PageableExecutionUtils.getPage(result, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/infrastructure/jpa/CodeRoomCustomRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/infrastructure/jpa/CodeRoomCustomRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface CodeRoomCustomRepository {
     Page<InvitationCodeRoom> findInvitedCodeRoomsByUser(User user, Pageable pageable);
     List<User> findUserListByUserCodeRoom(UserCodeRoom userCodeRoom);
-    Page<UserCodeRoom> findAllByEmailAndIsActivatedTrue(String email, Pageable pageable);
+    Page<UserCodeRoom> findAllUserCodeRoomByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/service/ParticipationServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/service/ParticipationServiceImpl.java
@@ -4,10 +4,13 @@ import com.gagoo.thiscoding.domain.maria.coderoom.controller.port.ParticipationS
 import com.gagoo.thiscoding.domain.maria.coderoom.controller.response.ParticipatingCodeRoomResponse;
 import com.gagoo.thiscoding.domain.maria.coderoom.domain.CodeRoom;
 import com.gagoo.thiscoding.domain.maria.coderoom.infrastructure.jpa.CodeRoomCustomRepository;
+import com.gagoo.thiscoding.domain.maria.coderoom.service.exception.CodeRoomNotFoundException;
 import com.gagoo.thiscoding.domain.maria.coderoom.service.port.CodeRoomRepository;
+import com.gagoo.thiscoding.domain.maria.user.domain.User;
+import com.gagoo.thiscoding.domain.maria.user.service.port.UserRepository;
 import com.gagoo.thiscoding.domain.maria.usercoderoom.domain.UserCodeRoom;
 import com.gagoo.thiscoding.domain.maria.usercoderoom.service.port.UserCodeRoomRepository;
-import com.gagoo.thiscoding.domain.mongo.code.service.exception.CodeNotFoundException;
+import com.gagoo.thiscoding.domain.maria.usercoderoom.service.exception.NotUserCodeRoomParticipantException;
 import com.gagoo.thiscoding.global.exception.ErrorCode;
 import com.gagoo.thiscoding.global.paging.PageSize;
 import com.gagoo.thiscoding.domain.auth.service.port.SecurityUtils;
@@ -26,6 +29,7 @@ public class ParticipationServiceImpl implements ParticipationService {
     private final CodeRoomRepository codeRoomRepository;
     private final UserCodeRoomRepository userCodeRoomRepository;
     private final CodeRoomCustomRepository codeRoomCustomRepository;
+    private final UserRepository userRepository;
     private final SecurityUtils securityUtils;
 
     /**
@@ -47,10 +51,16 @@ public class ParticipationServiceImpl implements ParticipationService {
      * @param id
      */
     @Override
-    public void accessUserCodeRoom(Long id) {
+    public boolean accessUserCodeRoom(Long id) {
         UserCodeRoom userCodeRoom = userCodeRoomRepository.getById(id);
 
-        userCodeRoomRepository.save(userCodeRoom.access());
+        validateUser(userCodeRoom);
+
+        if(userCodeRoomRepository.save(userCodeRoom.access()) == null) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -58,18 +68,33 @@ public class ParticipationServiceImpl implements ParticipationService {
      * @param id
      */
     @Override
-    public void leaveUserCodeRoom(Long id) {
+    public boolean leaveUserCodeRoom(Long id) {
         UserCodeRoom userCodeRoom = userCodeRoomRepository.getById(id);
-        userCodeRoomRepository.deleteById(id);
+
+        validateUser(userCodeRoom);
+
+        userCodeRoomRepository.deleteById(userCodeRoom.getId());
 
         CodeRoom codeRoom = codeRoomRepository.findById(userCodeRoom.getCodeRoom().getId()).orElseThrow(
-                () -> new CodeNotFoundException(ErrorCode.CODE_NOT_FOUND)
+                () -> new CodeRoomNotFoundException(ErrorCode.CODE_ROOM_NOT_FOUND)
         );
 
         if(codeRoom.getHeadCount() > MIN_CAPACITY) {
             codeRoomRepository.save(codeRoom.exit());
         } else {
             codeRoomRepository.deleteById(codeRoom.getId());
+        }
+
+        return true;
+    }
+
+    /**
+     * 코드방 참여자 여부 확인
+     */
+    private void validateUser(UserCodeRoom userCodeRoom) {
+        User currentUser = userRepository.getByEmail(securityUtils.getUserEmail());
+        if(!userCodeRoom.getUser().equals(currentUser)) {
+            throw new NotUserCodeRoomParticipantException(ErrorCode.NOT_USER_CODE_ROOM_PARTICIPANT);
         }
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/service/ParticipationServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/service/ParticipationServiceImpl.java
@@ -39,9 +39,10 @@ public class ParticipationServiceImpl implements ParticipationService {
     @Override
     public Page<ParticipatingCodeRoomResponse> getParticipations(Pageable pageable) {
         Pageable customPageable = PageRequest.of(pageable.getPageNumber(), PageSize.CODEROOM);
+        User currentUser = userRepository.getByEmail(securityUtils.getUserEmail());
 
         Page<UserCodeRoom> userCodeRoomPage = codeRoomCustomRepository
-                .findAllByEmailAndIsActivatedTrue(securityUtils.getUserEmail(), customPageable);
+                .findAllUserCodeRoomByUser(currentUser, customPageable);
 
         return userCodeRoomPage.map(userCodeRoom -> ParticipatingCodeRoomResponse.from(userCodeRoom, codeRoomCustomRepository.findUserListByUserCodeRoom(userCodeRoom)));
     }


### PR DESCRIPTION
** 변경사항 **
--

- `ParticipationService`
  - `accessUserCodeRoom`, `leaveUserCodeRoom` 반환 값을 void에서 boolean으로 변경
  -  `validateUser` 메서드 추가하여 코드방 참여자 여부 검증

- `ParticipationController`
  - `accessParticipation`, `leaveParticipation` 반환 값을 void에서 Boolean으로 변경

- `CodeRoomCustomRepositoryImpl`
  - `findAllByEmailAndIsActivatedTrue` → `findAllUserCodeRoomByUser` 메서드 명 변경
  - `findAllUserCodeRoomByUser` 파라미터를 이메일 값 대신 User 객체를 전달받도록 변경
  - `findAllUserCodeRoomByUser` 쿼리문의 where 조건절에 대해 특정 사용자와 동일한지만을 검증하도록 변경