### PR TITLE
test: CodeRoomRepositoryImplTest 관련 SQL 파일 구문 수정

### DIFF
--- a/src/test/java/com/gagoo/thiscoding/domain/maria/coderoom/infrastructure/impl/CodeRoomRepositoryImplTest.java
+++ b/src/test/java/com/gagoo/thiscoding/domain/maria/coderoom/infrastructure/impl/CodeRoomRepositoryImplTest.java
@@ -1,6 +1,5 @@
 package com.gagoo.thiscoding.domain.maria.coderoom.infrastructure.impl;
 
-import com.gagoo.thiscoding.ThiscodingApplication;
 import com.gagoo.thiscoding.domain.maria.coderoom.domain.CodeRoom;
 import com.gagoo.thiscoding.domain.maria.coderoom.infrastructure.jpa.CodeRoomCustomRepository;
 import com.gagoo.thiscoding.domain.maria.user.domain.User;
@@ -11,13 +10,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +22,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(classes = ThiscodingApplication.class)
+@SpringBootTest
 @Transactional
 @ActiveProfiles(profiles = {"test"})
 @Sql(scripts = "/sql/coderoom-test-data.sql")

--- a/src/test/resources/sql/coderoom-test-data.sql
+++ b/src/test/resources/sql/coderoom-test-data.sql
@@ -1,7 +1,9 @@
--- SET REFERENTIAL_INTEGRITY TRUE;
-DROP TABLE users CASCADE;
-DROP TABLE user_code_room CASCADE;
-DROP TABLE code_room CASCADE;
+-- 외래키 제약 조건 비활성화 후 테이블 삭제
+SET FOREIGN_KEY_CHECKS = 0;
+DROP TABLE IF EXISTS user_code_room;
+DROP TABLE IF EXISTS code_room;
+DROP TABLE IF EXISTS users;
+SET FOREIGN_KEY_CHECKS = 1;
 
 -- 테이블 생성
 CREATE TABLE users (


### PR DESCRIPTION
**변경 사항**
--

- `CodeRoomRepositoryImplTest` 내 불필요한 코드 제외
- `coderoom-test-data` 내 외래키 제약 비활성화 구문 추가
  - H2는 기본적으로 외래키 제약 활성화 상태
  - 테스트 종료 후 테이블을 자동 삭제하는 `ddl-auto: create-drop` 설정의 경우, 외래키 제약을 무시하거나 자동으로 처리하지 않음
  - 따라서 SQL 파일 내에서 직접 외래키 제약 비활성화를 위해 `SET FOREIGN_KEY_CHECKS = 0;` 추가