### PR TITLE
fix: 답변 조회 시, 비 로그인 상태일 경우 오류 수정

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/auth/infrastructure/SecurityUtilsImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/auth/infrastructure/SecurityUtilsImpl.java
@@ -21,6 +21,17 @@ public class SecurityUtilsImpl implements SecurityUtils {
         return user.getEmail();
     }
 
+    @Override
+    public boolean isLogin() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if(authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
+            return false;
+        }
+
+        return true;
+    }
+
     /**
      * SecurityContextHolder에 저장된 유저 정보 반환
      */

--- a/src/main/java/com/gagoo/thiscoding/domain/auth/service/port/SecurityUtils.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/auth/service/port/SecurityUtils.java
@@ -2,4 +2,5 @@ package com.gagoo.thiscoding.domain.auth.service.port;
 
 public interface SecurityUtils {
     String getUserEmail();
+    boolean isLogin();
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
@@ -52,7 +52,6 @@ public class BoardReadController {
         return ResponseEntity.ok(CustomPageDto.of(answerPage.map(AnswerListResponse::from)));
     }
 
-
     @GetMapping("/search")
     @ConvertToOneBase
     public ResponseEntity<CustomPageDto<SearchResponse>> search(@RequestParam String keyword, Pageable pageable) {

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
@@ -126,13 +126,18 @@ public class BoardServiceImpl implements BoardService {
      */
     @Override
     public Page<AnswerList> findAnswersByQnaId(String qnaId, Pageable pageable) {
-        Long currentUserId = getCurrentUser().getId();
+        if(securityUtils.isLogin()) {
+            Long currentUserId = getCurrentUser().getId();
+
+            return boardRepository.findAnswerByQnaId(qnaId, pageable)
+                    .map(board -> {
+                        boolean isLike = getIsLikeByQnaIdAndUserId(board.getId(), currentUserId);
+                        return AnswerList.from(board, isLike);
+                    });
+        }
 
         return boardRepository.findAnswerByQnaId(qnaId, pageable)
-                .map(board -> {
-                    boolean isLike = getIsLikeByQnaIdAndUserId(board.getId(), currentUserId);
-                    return AnswerList.from(board, isLike);
-                });
+                .map(board -> AnswerList.from(board, false));
     }
 
     /**

--- a/src/test/java/com/gagoo/thiscoding/global/security/infrastructure/FakeSecurityUtils.java
+++ b/src/test/java/com/gagoo/thiscoding/global/security/infrastructure/FakeSecurityUtils.java
@@ -19,4 +19,13 @@ public class FakeSecurityUtils implements SecurityUtils {
         return email;
     }
 
+    @Override
+    public boolean isLogin() {
+        if(email == null) {
+            return false;
+        }
+
+        return true;
+    }
+
 }


### PR DESCRIPTION
**변경 사항**
--

- `SecurityUtils` 내 로그인 여부 검증 후, 예외 처리가 아닌 `boolean` 값을 반환하는 `isLogin` 메서드 추가
- `BoardServiceImpl` 내 `findAnswerByQnaId` 메서드에서 로그인 및 비로그인 상태 구분하여 처리되도록 수정