### PR TITLE
fix: 답변 조회 시, 정렬 방법 변경

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardCustomRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardCustomRepository.java
@@ -2,6 +2,8 @@ package com.gagoo.thiscoding.domain.mongo.board.infrastructure.impl;
 
 import com.gagoo.thiscoding.domain.mongo.board.infrastructure.BoardDocument;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
@@ -10,9 +12,11 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.bson.Document;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import static org.springframework.data.mongodb.core.aggregation.Aggregation.*;
@@ -55,6 +59,36 @@ public class BoardCustomRepository {
         AggregationResults<Document> results =
                 mongoTemplate.aggregate(aggregation, "board", Document.class);
         return results;
+    }
+
+    /**
+     * 채택 답변 우선 정렬하여 조회
+     */
+    public Page<BoardDocument> getAnswerByQnaIdSortByIsSelected(String qnaId, Pageable pageable) {
+        Aggregation aggregation = getSelectedAnswerPriorityAggregation(qnaId, pageable);
+
+        AggregationResults<BoardDocument> results = mongoTemplate.aggregate(aggregation, "qna", BoardDocument.class);
+
+        List<BoardDocument> answerList = results.getMappedResults();
+
+        LongSupplier totalSupplier = () -> mongoTemplate.count(new Query(Criteria.where("parentId").is(qnaId)), "qna");
+
+        return PageableExecutionUtils.getPage(answerList, pageable, totalSupplier);
+    }
+
+    /**
+     * 채택된 답변 우선 정렬 및 내림차순 조회 쿼리
+     */
+    private Aggregation getSelectedAnswerPriorityAggregation(String qnaId, Pageable pageable) {
+        Aggregation aggregation = Aggregation.newAggregation(
+            match(Criteria.where("parentId").is(qnaId)),
+                sort(Sort.by(Sort.Order.desc("isSelected"),
+                        Sort.Order.desc("createDate"))),
+                skip((long) pageable.getPageNumber() * pageable.getPageSize()),
+                limit(pageable.getPageSize())
+        );
+
+        return aggregation;
     }
 
     /**

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/infrastructure/impl/BoardRepositoryImpl.java
@@ -115,6 +115,11 @@ public class BoardRepositoryImpl implements BoardRepository {
     }
 
     @Override
+    public Page<Board> findAnswerByQnaIdSortByIsSelected(String qnaId, Pageable pageable) {
+        return boardCustomRepository.getAnswerByQnaIdSortByIsSelected(qnaId, pageable).map(BoardDocument::toModel);
+    }
+
+    @Override
     public Board save(Board board) {
         return boardMongoRepository.save(BoardDocument.from(board)).toModel();
     }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
@@ -126,17 +126,18 @@ public class BoardServiceImpl implements BoardService {
      */
     @Override
     public Page<AnswerList> findAnswersByQnaId(String qnaId, Pageable pageable) {
+        // 로그인 상태일 경우, 답변 추천 여부 조회
         if(securityUtils.isLogin()) {
             Long currentUserId = getCurrentUser().getId();
 
-            return boardRepository.findAnswerByQnaId(qnaId, pageable)
+            return boardRepository.findAnswerByQnaIdSortByIsSelected(qnaId, pageable)
                     .map(board -> {
                         boolean isLike = getIsLikeByQnaIdAndUserId(board.getId(), currentUserId);
                         return AnswerList.from(board, isLike);
                     });
         }
 
-        return boardRepository.findAnswerByQnaId(qnaId, pageable)
+        return boardRepository.findAnswerByQnaIdSortByIsSelected(qnaId, pageable)
                 .map(board -> AnswerList.from(board, false));
     }
 

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/port/BoardRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/port/BoardRepository.java
@@ -16,6 +16,7 @@ public interface BoardRepository {
     Page<Board> findByUserIdAndParentIdIsNotRoot(Long userId, Pageable pageable);
     Page<Search> findByTitleOrContent(String title, String content, Pageable pageable);
     Page<Board> findAnswerByQnaId(String qnaId, Pageable pageable);
+    Page<Board> findAnswerByQnaIdSortByIsSelected(String qnaId, Pageable pageable);
     boolean existsById(String qnaId);
     boolean existsByParentIdAndIsSelectedIsTrue(String qnaId);
     void incrementViewCount(String qnaId);

--- a/src/test/java/com/gagoo/thiscoding/domain/mock/FakeBoardRepository.java
+++ b/src/test/java/com/gagoo/thiscoding/domain/mock/FakeBoardRepository.java
@@ -86,7 +86,6 @@ public class FakeBoardRepository implements BoardRepository {
         return null;
     }
 
-
     @Override
     public Page<Search> findByTitleOrContent(String title, String content, Pageable pageable) {
         return null;
@@ -94,6 +93,11 @@ public class FakeBoardRepository implements BoardRepository {
 
     @Override
     public Page<Board> findAnswerByQnaId(String qnaId, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public Page<Board> findAnswerByQnaIdSortByIsSelected(String qnaId, Pageable pageable) {
         return null;
     }
 


### PR DESCRIPTION
**변경 사항**
--

- 답변 조회 시, 채택된 답변이 있으면 가장 먼저 조회하는 `getAnswerByQnaIdSortByIsSelected` 메서드 추가
- `BoardRepositoryImpl`, `BoardServiceImpl`, `FakeBoardRepository` 내 관련 사항 수정