### PR TITLE
refactor: 쿠키 조회 메서드 리팩터링

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/global/common/util/HttpServletUtils.java
+++ b/src/main/java/com/gagoo/thiscoding/global/common/util/HttpServletUtils.java
@@ -1,7 +1,5 @@
 package com.gagoo.thiscoding.global.common.util;
 
-import static java.util.Optional.empty;
-
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -45,13 +43,13 @@ public class HttpServletUtils {
 
     public Optional<Cookie> getCookie(HttpServletRequest request, String name) {
         Cookie[] cookies = request.getCookies();
-
-        if (cookies != null && cookies.length > 0) {
-            return Arrays.stream(cookies)
-                    .filter(cookie -> cookie.getName().equals(name))
-                    .findAny();
+        if (cookies == null) {
+            return Optional.empty();
         }
 
-        return empty();
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookie.getName().equals(name))
+                .findAny();
     }
+
 }


### PR DESCRIPTION
length 체크는 null이 아닐경우 어차피 0 이상이기 때문에 불필요하다 판단하여 삭제