### PR TITLE
fix: 코드방 내 마지막 메시지 저장 및 전송

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/code/controller/CodeSocketController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/code/controller/CodeSocketController.java
@@ -2,19 +2,40 @@ package com.gagoo.thiscoding.domain.mongo.code.controller;
 
 import com.gagoo.thiscoding.domain.mongo.code.domain.dto.CodeSocket;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 @Controller
 @RequiredArgsConstructor
 public class CodeSocketController {
     private final SimpMessagingTemplate messagingTemplate;
 
+    // 마지막 메시지 저장 변수
+    // <roomId + codeId, 마지막 메시지 값>
+    private final ConcurrentHashMap<String, String> lastMessages = new ConcurrentHashMap<>();
+
     @MessageMapping("/broadcast-code") // 클라이언트가 /pub/broadcast로 메시지를 보낼 때 호출
     @SendTo("/sub/codingrooms") // 해당 메시지를 /sub/codingrooms를 구독 중인 모든 클라이언트에게 브로드캐스트
     public void broadcastCode(CodeSocket codeSocket) {
-        messagingTemplate.convertAndSend("/sub/codingrooms/" + codeSocket.getRoomId(), codeSocket.getValue());
+        // 마지막 메시지 값 저장
+        lastMessages.put(codeSocket.getRoomId() + codeSocket.getCodeId(), codeSocket.getValue());
+
+        // 해당 경로를 구독 중인 모든 클라이언트에게 메시지 전송
+        messagingTemplate.convertAndSend("/sub/codingrooms/" + codeSocket.getRoomId() + "/" + codeSocket.getCodeId(), codeSocket.getValue());
+    }
+
+    // 새로운 클라이언트가 구독 시, 마지막 메시지 전송
+    @MessageMapping("/codingrooms/join/{roomId}/{codeId}")
+    public void sendLastMessage(@DestinationVariable Long roomId, @DestinationVariable String codeId) {
+        String lastMessage = lastMessages.get(roomId + codeId);
+
+        if (lastMessage != null) {
+            messagingTemplate.convertAndSend("/sub/codingrooms/" + roomId + "/" + codeId, lastMessage);
+        }
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/code/domain/dto/CodeSocket.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/code/domain/dto/CodeSocket.java
@@ -9,11 +9,14 @@ public class CodeSocket {
     @NotBlank
     private final Long roomId;
     @NotBlank
+    private final String codeId;
+    @NotBlank
     private final String value;
 
     @Builder
-    public CodeSocket(final Long roomId, final String value) {
+    public CodeSocket(final Long roomId, final String codeId, final String value) {
         this.roomId = roomId;
+        this.codeId = codeId;
         this.value = value;
     }
 }


### PR DESCRIPTION
**변경 사항**
--

- `CodeSocket` 내 `String` 타입 `codeId` 속성 추가
- `CodeSocketController` 내 마지막 메시지 저장을 위한 `ConcurrentHashMap` 타입의 `lastMessages` 변수 선언
- `CodeSocketController` 내 메시지 전송 역할을 하는 `broadCast` 메서드에서 전송될 값인 `codeSocket.getValue()`를 `lastMessages`에 저장 후 전송하도록 변경
- `CodeSocketController` 내 `broadCast` 메서드에서 전송 목적지 변경
- `CodeSocketController` 내 새로운 클라이언트가 구독 시 `lastMessages`의 key 값이 `roomId + codeId`에 대한 value 값을 특정 목적지의 클라이언트에게 전송하는 `sendLastMessage` 메서드 추가