### PR TITLE
feat:공통 Api Response 구현

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/bookmark/controller/BookmarkWriteController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/bookmark/controller/BookmarkWriteController.java
@@ -2,6 +2,7 @@ package com.gagoo.thiscoding.domain.maria.bookmark.controller;
 
 import com.gagoo.thiscoding.domain.maria.bookmark.controller.port.BookmarkService;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,18 +18,18 @@ public class BookmarkWriteController {
     // 북마크
     @PostMapping("/{qnaId}/bookmark")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<String> bookmarkQna(@PathVariable String qnaId) {
+    public ApiResponse<String> bookmarkQna(@PathVariable String qnaId) {
         bookmarkService.bookmarkQna(qnaId);
 
-        return ResponseEntity.ok("게시글 북마크가 완료되었습니다.");
+        return ApiResponse.ok(null,"게시글 북마크가 완료되었습니다.");
     }
 
     // 북마크 취소
     @DeleteMapping("/{qnaId}/cancel-bookmark")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<String> cancelQnaBookmark(@PathVariable String qnaId) {
+    public ApiResponse<String> cancelQnaBookmark(@PathVariable String qnaId) {
         bookmarkService.cancelQnaBookmark(qnaId);
 
-        return ResponseEntity.ok("북마크를 취소하였습니다.");
+        return ApiResponse.ok(null,"북마크를 취소하였습니다.");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/CodeRoomController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/CodeRoomController.java
@@ -4,6 +4,7 @@ import com.gagoo.thiscoding.domain.maria.coderoom.controller.port.CodeRoomServic
 import com.gagoo.thiscoding.domain.maria.coderoom.controller.response.CodeRoomEnterResponse;
 import com.gagoo.thiscoding.domain.maria.coderoom.domain.dto.CodeRoomEnter;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,10 +23,10 @@ public class CodeRoomController {
     // 코드방 입장 (조회)
     @GetMapping("/{uuid}")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CodeRoomEnterResponse> enterCodeRoom(@PathVariable String uuid) {
+    public ApiResponse<CodeRoomEnterResponse> enterCodeRoom(@PathVariable String uuid) {
         CodeRoomEnter codeRoomEnter = codeRoomService.enterCodeRoom(uuid);
 
-        return ResponseEntity
-                .ok(CodeRoomEnterResponse.from(codeRoomEnter));
+        return ApiResponse
+                .ok(CodeRoomEnterResponse.from(codeRoomEnter),"코드방 입장 성공");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/CodeRoomCreateController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/CodeRoomCreateController.java
@@ -5,6 +5,7 @@ import com.gagoo.thiscoding.domain.maria.coderoom.controller.response.CodeRoomCr
 import com.gagoo.thiscoding.domain.maria.coderoom.domain.CodeRoom;
 import com.gagoo.thiscoding.domain.maria.coderoom.domain.dto.CodeRoomCreate;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,11 +25,9 @@ public class CodeRoomCreateController {
     // 코드방 생성
     @PostMapping
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CodeRoomCreateResponse> createCodeRoom(@RequestBody CodeRoomCreate codeRoomCreate) {
+    public ApiResponse<CodeRoomCreateResponse> createCodeRoom(@RequestBody CodeRoomCreate codeRoomCreate) {
         CodeRoom codeRoom = codeRoomService.createCodeRoom(codeRoomCreate);
 
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(CodeRoomCreateResponse.from(codeRoom));
+        return ApiResponse.created(CodeRoomCreateResponse.from(codeRoom), "코드방 생성 성공");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/InvitationController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/InvitationController.java
@@ -3,6 +3,7 @@ package com.gagoo.thiscoding.domain.maria.coderoom.controller;
 import com.gagoo.thiscoding.domain.maria.coderoom.controller.port.InvitationService;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
 import com.gagoo.thiscoding.domain.maria.coderoom.controller.response.InvitationCodeRoomResponse;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.paging.aop.ConvertToOneBase;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
@@ -27,28 +28,24 @@ public class InvitationController {
     @GetMapping
     @ConvertToOneBase
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CustomPageDto<InvitationCodeRoomResponse>> CodeRoomInviteListView(Pageable pageable) {
+    public ApiResponse<CustomPageDto<InvitationCodeRoomResponse>> CodeRoomInviteListView(Pageable pageable) {
         Page<InvitationCodeRoomResponse> codeRooms = invitationService.getInvitationCodeRoomList(pageable).map(InvitationCodeRoomResponse::from);
-        return ResponseEntity
-            .ok()
-            .body(CustomPageDto.of(codeRooms));
+        return ApiResponse
+                .ok(CustomPageDto.of(codeRooms), "");
     }
 
     @PutMapping("/alarms/{alarmId}/codeRooms/{codeRoomId}")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<?> acceptInvitation(@PathVariable Long codeRoomId, @PathVariable Long alarmId) {
+    public ApiResponse<?> acceptInvitation(@PathVariable Long codeRoomId, @PathVariable Long alarmId) {
         invitationService.acceptInvitationCodeRoom(codeRoomId,alarmId);
-        return ResponseEntity
-            .ok()
-            .body("수락 완료");
+        return ApiResponse
+            .ok(null,"수락 완료");
     }
 
     @DeleteMapping("/alarms/{alarmId}/codeRooms/{codeRoomId}")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<?> rejectInvitation(@PathVariable Long codeRoomId, @PathVariable Long alarmId) {
+    public ApiResponse<?> rejectInvitation(@PathVariable Long codeRoomId, @PathVariable Long alarmId) {
         invitationService.rejectInvitationCodeRoom(codeRoomId, alarmId);
-        return ResponseEntity
-            .ok()
-            .body("거절 완료");
+        return ApiResponse.ok(null, "거절 완료");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/ParticipationController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/coderoom/controller/ParticipationController.java
@@ -3,6 +3,7 @@ package com.gagoo.thiscoding.domain.maria.coderoom.controller;
 import com.gagoo.thiscoding.domain.maria.coderoom.controller.port.ParticipationService;
 import com.gagoo.thiscoding.domain.maria.coderoom.controller.response.ParticipatingCodeRoomResponse;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.paging.aop.ConvertToOneBase;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
@@ -23,28 +24,23 @@ public class ParticipationController {
     @GetMapping
     @ConvertToOneBase
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CustomPageDto<ParticipatingCodeRoomResponse>> getParticipationList(Pageable pageable) {
+    public ApiResponse<CustomPageDto<ParticipatingCodeRoomResponse>> getParticipationList(Pageable pageable) {
         Page<ParticipatingCodeRoomResponse> userCodeRooms = participationService.getParticipations(pageable);
-        return ResponseEntity
-                .ok()
-                .body(CustomPageDto.of(userCodeRooms));
+        return ApiResponse
+                .ok(CustomPageDto.of(userCodeRooms), "참여 중인 코드방 목록 조회 성공");
     }
 
     // 참여 중인 코드방 입/퇴장
     @PatchMapping("/{id}/access")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<Boolean> accessParticipation(@PathVariable Long id) {
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(participationService.accessUserCodeRoom(id));
+    public ApiResponse<Boolean> accessParticipation(@PathVariable Long id) {
+        return ApiResponse.ok(participationService.accessUserCodeRoom(id),"참여 중인 코드방 입/퇴장 성공");
     }
 
     // 참여 중인 코드방 탈퇴
     @DeleteMapping("/{id}/leave")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<Boolean> leaveParticipation(@PathVariable Long id) {
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(participationService.leaveUserCodeRoom(id));
+    public ApiResponse<Boolean> leaveParticipation(@PathVariable Long id) {
+        return ApiResponse.ok(participationService.leaveUserCodeRoom(id), "참여 중인 코드방 탈퇴 성공");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/like/controller/LikeWriteController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/like/controller/LikeWriteController.java
@@ -2,6 +2,7 @@ package com.gagoo.thiscoding.domain.maria.like.controller;
 
 import com.gagoo.thiscoding.domain.maria.like.controller.port.LikeService;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,18 +18,18 @@ public class LikeWriteController {
     // 답변 추천
     @PostMapping("/{qnaId}/like")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<String> likeAnswer(@PathVariable String qnaId) {
+    public ApiResponse<String> likeAnswer(@PathVariable String qnaId) {
         likeService.likeAnswer(qnaId);
 
-        return ResponseEntity.ok().body("답변 추천이 완료되었습니다.");
+        return ApiResponse.ok(null,"답변 추천이 완료되었습니다.");
     }
 
     // 답변 추천 취소
     @DeleteMapping("/{qnaId}/cancel-like")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<String> cancelAnswerLike(@PathVariable String qnaId) {
+    public ApiResponse<String> cancelAnswerLike(@PathVariable String qnaId) {
         likeService.cancelAnswerLike(qnaId);
 
-        return ResponseEntity.ok().body("답변 추천을 취소하였습니다.");
+        return ApiResponse.ok(null,"답변 추천을 취소하였습니다.");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/manager/controller/ManagerNoticesController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/manager/controller/ManagerNoticesController.java
@@ -5,14 +5,13 @@ import com.gagoo.thiscoding.domain.maria.manager.controller.response.ManagerNoti
 import com.gagoo.thiscoding.domain.maria.manager.controller.response.ManagerNoticesList;
 import com.gagoo.thiscoding.domain.maria.manager.domain.ManagerNoticesUpdate;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.paging.aop.ConvertToOneBase;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -25,38 +24,35 @@ public class ManagerNoticesController {
     //공지사항 목록 조회
     @GetMapping
     @ConvertToOneBase
-    @AuthorizationRequired(value = {Role.ADMIN, Role.USER})
-    public ResponseEntity<Page<ManagerNoticesList>> getNoticesAll(Pageable pageable) {
-        return ResponseEntity
-                .ok()
-                .body(managerService.getAllManagerNotices(pageable).map(ManagerNoticesList::from));
+    public ApiResponse<Page<ManagerNoticesList>> getNoticesAll(Pageable pageable) {
+
+        return ApiResponse
+                .ok(managerService.getAllManagerNotices(pageable)
+                        .map(ManagerNoticesList::from), "공지사항 목록 조회 성공");
     }
 
     //공지사항 상세 조회
     @GetMapping("/{id}")
-    @AuthorizationRequired(value = {Role.ADMIN, Role.USER})
-    public ResponseEntity<ManagerNoticesDetail> getNoticesDetail(@PathVariable Long id) {
-        return ResponseEntity
-                .ok()
-                .body(ManagerNoticesDetail.from(managerService.getNotices(id)));
+    public ApiResponse<ManagerNoticesDetail> getNoticesDetail(@PathVariable Long id) {
+        return ApiResponse
+                .ok(ManagerNoticesDetail.from(managerService.getNotices(id)), "공지사항 상세 조회 성공");
     }
 
     //공지사항 수정
     @PatchMapping("/{id}")
     @AuthorizationRequired(value = {Role.ADMIN})
-    public ResponseEntity<?> updateManagerNotices(@PathVariable Long id, @RequestBody ManagerNoticesUpdate request) {
+    public ApiResponse<?> updateManagerNotices(@PathVariable Long id, @RequestBody ManagerNoticesUpdate request) {
 
         managerService.updateAdminNotices(id, request);
-        return ResponseEntity.ok("공지사항 수정이 완료되었습니다.");
+        return ApiResponse.ok(null, "공지사항 수정 완료");
     }
 
     //공지사항 삭제
     @DeleteMapping("/{id}")
-    @AuthorizationRequired(value = {Role.ADMIN})
-    public ResponseEntity<?> deleteManagerNotices(@PathVariable Long id) {
+    @AuthorizationRequired(value = {Role.ADMIN, Role.USER})
+    public ApiResponse<?> deleteManagerNotices(@PathVariable Long id) {
         managerService.deleteManagerNotices(id);
-        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        return ApiResponse.ok(null, "공지사항 삭제 완료");
     }
-
 
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/reply/controller/ReplyReadController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/reply/controller/ReplyReadController.java
@@ -3,6 +3,7 @@ package com.gagoo.thiscoding.domain.maria.reply.controller;
 import com.gagoo.thiscoding.domain.maria.reply.controller.port.ReplyService;
 import com.gagoo.thiscoding.domain.maria.reply.service.dto.ReplyList;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.paging.aop.ConvertToOneBase;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
@@ -23,15 +24,15 @@ public class ReplyReadController {
 
     @GetMapping("/{qnaId}/reply")
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<ReplyList>> getQnAReply(@PathVariable String qnaId, Pageable pageable) {
-        return ResponseEntity.ok(replyService.getQnAReply(qnaId, pageable));
+    public ApiResponse<CustomPageDto<ReplyList>> getQnAReply(@PathVariable String qnaId, Pageable pageable) {
+        return ApiResponse.ok(replyService.getQnAReply(qnaId, pageable),"댓글 목록 조회 완료");
     }
 
     @GetMapping("/{qnaId}/reply/{parentId}")
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<ReplyList>> getReplies(@PathVariable String qnaId,
+    public ApiResponse<CustomPageDto<ReplyList>> getReplies(@PathVariable String qnaId,
                                                                @PathVariable Long parentId,Pageable pageable){
-        return ResponseEntity.ok(replyService.getReplies(qnaId,parentId, pageable));
+        return ApiResponse.ok(replyService.getReplies(qnaId,parentId, pageable),"대댓글 목록 조회 완료");
     }
 
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/reply/controller/ReplyWriteController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/reply/controller/ReplyWriteController.java
@@ -3,6 +3,7 @@ package com.gagoo.thiscoding.domain.maria.reply.controller;
 import com.gagoo.thiscoding.domain.maria.reply.controller.port.ReplyService;
 import com.gagoo.thiscoding.domain.maria.reply.domain.dto.ReplyCreate;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,18 +18,17 @@ public class ReplyWriteController {
 
     @PostMapping("/{qnaId}/reply")
     @AuthorizationRequired(value = {Role.USER, Role.ADMIN})
-    public ResponseEntity<Void> create(@PathVariable String qnaId,@RequestBody ReplyCreate replyCreate) {
+    public ApiResponse<Void> create(@PathVariable String qnaId, @RequestBody ReplyCreate replyCreate) {
 
         replyService.create(qnaId, replyCreate);
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.ok(null, "댓글 작성 성공");
     }
 
     @DeleteMapping("/{qnaId}/reply/{replyId}")
-    public ResponseEntity<String> delete(@PathVariable String qnaId, @PathVariable Long replyId) {
+    public ApiResponse<String> delete(@PathVariable String qnaId, @PathVariable Long replyId) {
         replyService.delete(qnaId, replyId);
-        return ResponseEntity
-            .ok()
-            .body("댓글이 삭제되었습니다.");
+        return ApiResponse.ok(null, "댓글 삭제 성공");
+
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/CertificationController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/CertificationController.java
@@ -3,6 +3,7 @@ package com.gagoo.thiscoding.domain.maria.user.controller;
 import com.gagoo.thiscoding.domain.maria.user.controller.port.CertificationService;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
 import com.gagoo.thiscoding.domain.maria.user.domain.dto.AuthCode;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -23,29 +24,29 @@ public class CertificationController {
      * 회원가입 인증코드 발송
      */
     @GetMapping("/join-code")
-    public ResponseEntity<Void> sendJoinCode(@NotBlank @RequestParam String email) {
+    public ApiResponse<Void> sendJoinCode(@NotBlank @RequestParam String email) {
         certificationService.sendJoinCode(email);
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.ok(null, "인증 코드 발송 성공");
     }
 
     /**
      * 임시 비밀번호 발송
      */
     @GetMapping("/temporary-password")
-    public ResponseEntity<String> temporaryPassword(@NotBlank @RequestParam String email) {
+    public ApiResponse<String> temporaryPassword(@NotBlank @RequestParam String email) {
         certificationService.sendTemporaryPassword(email);
 
-        return ResponseEntity.ok().body("임시 비밀번호 발급");
+        return ApiResponse.ok(null,"임시 비밀번호 발급 성공");
     }
 
     /**
      * 인증코드 확인
      */
     @PostMapping("/auth-code/check")
-    public ResponseEntity<Void> checkJoinCode(@Valid @RequestBody AuthCode authCode) {
+    public ApiResponse<Void> checkJoinCode(@Valid @RequestBody AuthCode authCode) {
         certificationService.checkAuthCode(authCode);
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.ok(null, "인증코드 확인 성공");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/MyPageController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/MyPageController.java
@@ -7,6 +7,7 @@ import com.gagoo.thiscoding.domain.maria.user.controller.response.Top10StatusRes
 import com.gagoo.thiscoding.domain.maria.user.controller.response.UserProfile;
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
 import com.gagoo.thiscoding.domain.maria.user.domain.dto.UpdateProfileImageRequest;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.paging.aop.ConvertToOneBase;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
@@ -26,33 +27,32 @@ public class MyPageController {
 
     @GetMapping("/me/top10")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<Top10StatusResponse> get() {
-        return ResponseEntity
-                .ok(Top10StatusResponse.from(myPageService.isTop10()));
+    public ApiResponse<Top10StatusResponse> get() {
+        return ApiResponse
+                .ok(Top10StatusResponse.from(myPageService.isTop10()),"Top10 여부 조회 성공");
     }
 
     @PatchMapping("/me/profile/nickname")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<String> updateProfileNickname(@RequestBody UpdateProfileNicknameRequest request) {
+    public ApiResponse<String> updateProfileNickname(@RequestBody UpdateProfileNicknameRequest request) {
         userService.updateNickname(request);
-        return ResponseEntity.ok().body("닉네임 변경 완료");
+        return ApiResponse.ok(null,"닉네임 변경 완료");
     }
 
     @PatchMapping("/me/profile/image")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<String> updateProfileImage(@RequestBody UpdateProfileImageRequest request) {
+    public ApiResponse<String> updateProfileImage(@RequestBody UpdateProfileImageRequest request) {
         userService.updateImage(request);
-        return ResponseEntity.ok().body("프로필 사진 변경 완료");
+        return ApiResponse.ok(null,"프로필 사진 변경 완료");
     }
 
     @GetMapping("/search")
     @ConvertToOneBase
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CustomPageDto<UserProfile>> search (@RequestParam String keyword, Pageable pageable) {
+    public ApiResponse<CustomPageDto<UserProfile>> search (@RequestParam String keyword, Pageable pageable) {
         Page<UserProfile> result = userService.searchByNickname(keyword, pageable).map(UserProfile::from);
-        return ResponseEntity
-            .ok()
-            .body(CustomPageDto.of(result));
+        return ApiResponse
+                .ok(CustomPageDto.of(result), "유저 프로필 검색 성공");
     }
 
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/TokenReissueController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/TokenReissueController.java
@@ -3,6 +3,7 @@ package com.gagoo.thiscoding.domain.maria.user.controller;
 import com.gagoo.thiscoding.domain.auth.domain.Token;
 import com.gagoo.thiscoding.domain.auth.dto.TokenDto;
 import com.gagoo.thiscoding.domain.maria.user.controller.port.TokenReissueService;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.common.util.HttpServletUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,12 +24,12 @@ public class TokenReissueController {
     private final HttpServletUtils servletUtils;
 
     @GetMapping("/reissue")
-    private ResponseEntity<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
+    private ApiResponse<Void> reissue(HttpServletRequest request, HttpServletResponse response) {
         TokenDto tokenDto = TokenDto.from(tokenReissueService.create(request));
 
         servletUtils.setHeader(response, AUTHORIZATION, tokenDto.getAtk());
         servletUtils.addCookie(response, AUTHORIZATION, tokenDto.getRtk(), tokenDto.getRtkExpTime());
 
-        return ResponseEntity.ok().build();
+        return ApiResponse.ok(null,"Reissue 발급 성공");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/UserController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.gagoo.thiscoding.domain.maria.user.controller;
 
 import com.gagoo.thiscoding.domain.maria.user.controller.port.UserService;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,14 +14,14 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("email")
-    public ResponseEntity<Boolean> checkEmail(@RequestParam String email) {
-        return ResponseEntity
-                .ok(userService.checkEmailDuplicate(email));
+    public ApiResponse<Boolean> checkEmail(@RequestParam String email) {
+        return ApiResponse
+                .ok(userService.checkEmailDuplicate(email),"이메일 확인 성공");
     }
 
     @GetMapping("nickname")
-    public ResponseEntity<Boolean> checkNickname(@RequestParam String nickname) {
-        return ResponseEntity
-                .ok(userService.checkNicknameDuplicate(nickname));
+    public ApiResponse<Boolean> checkNickname(@RequestParam String nickname) {
+        return ApiResponse
+                .ok(userService.checkNicknameDuplicate(nickname),"닉네임 확인 성공");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/usercoderoom/controller/UserCodeRoomCreateController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/usercoderoom/controller/UserCodeRoomCreateController.java
@@ -2,6 +2,7 @@ package com.gagoo.thiscoding.domain.maria.usercoderoom.controller;
 
 import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
 import com.gagoo.thiscoding.domain.maria.usercoderoom.controller.port.UserCodeRoomService;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,9 +21,8 @@ public class UserCodeRoomCreateController {
     // 코드방 참여 생성
     @PostMapping("/{codeRoomId}")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<Boolean> createUserCodeRoom(@PathVariable Long codeRoomId) {
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(userCodeRoomService.createUserCodeRoom(codeRoomId));
+    public ApiResponse<Boolean> createUserCodeRoom(@PathVariable Long codeRoomId) {
+        return ApiResponse
+                .created(userCodeRoomService.createUserCodeRoom(codeRoomId),"코드방 참여 생성 성공");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardReadController.java
@@ -7,6 +7,7 @@ import com.gagoo.thiscoding.domain.mongo.board.controller.response.SearchRespons
 import com.gagoo.thiscoding.domain.mongo.board.service.dto.AnswerList;
 import com.gagoo.thiscoding.domain.mongo.board.service.dto.QnaList;
 import com.gagoo.thiscoding.domain.mongo.board.controller.port.VisitorIdProvider;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.paging.aop.ConvertToOneBase;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,33 +31,32 @@ public class BoardReadController {
     private final VisitorIdProvider visitorIdProvider;
 
     @GetMapping("/{qnaId}")
-    public ResponseEntity<QnaResponse> get(@PathVariable String qnaId, HttpServletRequest request, HttpServletResponse response) {
+    public ApiResponse<QnaResponse> get(@PathVariable String qnaId, HttpServletRequest request, HttpServletResponse response) {
         String visitorId = visitorIdProvider.getVisitorId(request, response);
 
-        return ResponseEntity
-                .ok()
-                .body(QnaResponse.from(boardService.get(qnaId, visitorId)));
+        return ApiResponse
+                .ok(QnaResponse.from(boardService.get(qnaId, visitorId)), "QnA 상세 조회 성공");
     }
 
     @GetMapping
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<QnaList>> getAll(Pageable pageable) {
-        return ResponseEntity.ok(boardService.findAll(pageable));
+    public ApiResponse<CustomPageDto<QnaList>> getAll(Pageable pageable) {
+        return ApiResponse.ok(boardService.findAll(pageable),"QnA 목록 조회 성공");
     }
 
     @GetMapping("/{qnaId}/answer")
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<AnswerListResponse>> getAnswersByQnaId(
+    public ApiResponse<CustomPageDto<AnswerListResponse>> getAnswersByQnaId(
             @PathVariable String qnaId, Pageable pageable) {
         Page<AnswerList> answerPage = boardService.findAnswersByQnaId(qnaId, pageable);
-        return ResponseEntity.ok(CustomPageDto.of(answerPage.map(AnswerListResponse::from)));
+        return ApiResponse.ok(CustomPageDto.of(answerPage.map(AnswerListResponse::from)),"QnA 답변 조회 성공");
     }
 
     @GetMapping("/search")
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<SearchResponse>> search(@RequestParam String keyword, Pageable pageable) {
+    public ApiResponse<CustomPageDto<SearchResponse>> search(@RequestParam String keyword, Pageable pageable) {
         Page<SearchResponse> searchResult = boardService.searchByKeyword(keyword, pageable).map(SearchResponse::from);
-        return ResponseEntity.ok(CustomPageDto.of(searchResult));
+        return ApiResponse.ok(CustomPageDto.of(searchResult),"검색 성공");
     }
 }
 

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardWriteController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/BoardWriteController.java
@@ -4,6 +4,7 @@ import com.gagoo.thiscoding.domain.maria.user.domain.contants.Role;
 import com.gagoo.thiscoding.domain.mongo.board.controller.port.BoardService;
 import com.gagoo.thiscoding.domain.mongo.board.controller.request.BoardAnswer;
 import com.gagoo.thiscoding.domain.mongo.board.domain.dto.BoardCreate;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,27 +19,26 @@ public class BoardWriteController {
 
     @PostMapping
     @AuthorizationRequired(value = {Role.USER, Role.ADMIN})
-    public ResponseEntity<Void> create(@RequestBody BoardCreate boardCreate) {
+    public ApiResponse<Void> create(@RequestBody BoardCreate boardCreate) {
         boardService.create(boardCreate);
 
-        return ResponseEntity.created(null).build();
+        return ApiResponse.created(null, "QnA 질문 작성 성공");
     }
 
     @PostMapping("/{qnaId}/answer")
     @AuthorizationRequired(value = {Role.USER, Role.ADMIN})
-    public ResponseEntity<Void> writeAnswer(@PathVariable String qnaId, @RequestBody BoardAnswer boardAnswer) {
+    public ApiResponse<Void> writeAnswer(@PathVariable String qnaId, @RequestBody BoardAnswer boardAnswer) {
         boardService.writeAnswer(qnaId, boardAnswer);
 
-        return ResponseEntity.created(null).build();
+        return ApiResponse.created(null, "QnA 답변 작성 성공");
     }
 
     @PostMapping("/{qnaId}/adopt")
     @AuthorizationRequired(value = {Role.USER, Role.ADMIN})
-    public ResponseEntity<String> adoptAnswer(@PathVariable String qnaId) {
+    public ApiResponse<String> adoptAnswer(@PathVariable String qnaId) {
         boardService.adoptAnswer(qnaId);
 
-        return ResponseEntity
-                .ok()
-                .body("답변이 채택되었습니다.");
+        return ApiResponse
+                .ok(null, "답변이 채택되었습니다.");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/MyQnaController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/controller/MyQnaController.java
@@ -5,6 +5,7 @@ import com.gagoo.thiscoding.domain.mongo.board.controller.port.BoardService;
 import com.gagoo.thiscoding.domain.mongo.board.controller.response.MyPageAnswer;
 import com.gagoo.thiscoding.domain.mongo.board.controller.response.MyPageBookmark;
 import com.gagoo.thiscoding.domain.mongo.board.controller.response.MyPageQnA;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.paging.aop.ConvertToOneBase;
 import com.gagoo.thiscoding.global.paging.dto.CustomPageDto;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
@@ -27,10 +28,10 @@ public class MyQnaController {
     @AuthorizationRequired(value = {Role.USER,Role.ADMIN})
     @GetMapping("/qna")
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<MyPageQnA>> getMyPageQnA(Pageable pageable) {
+    public ApiResponse<CustomPageDto<MyPageQnA>> getMyPageQnA(Pageable pageable) {
 
         Page<MyPageQnA> qnaResult = boardService.getMyPagePostQnA(pageable).map(MyPageQnA::from);
-        return ResponseEntity.ok(CustomPageDto.of(qnaResult));
+        return ApiResponse.ok(CustomPageDto.of(qnaResult),"마이페이지 작성한 QnA 질문 조회 완료");
 
     }
 
@@ -38,9 +39,9 @@ public class MyQnaController {
     @AuthorizationRequired(value = {Role.USER,Role.ADMIN})
     @GetMapping("/answer")
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<MyPageAnswer>> getMyPageAnswer(Pageable pageable) {
+    public ApiResponse<CustomPageDto<MyPageAnswer>> getMyPageAnswer(Pageable pageable) {
         Page<MyPageAnswer> answerResult = boardService.getMyPagePostAnswer(pageable).map(MyPageAnswer::from);
-        return ResponseEntity.ok(CustomPageDto.of(answerResult));
+        return ApiResponse.ok(CustomPageDto.of(answerResult),"마이페이지 작성한 QnA 답변 완료");
 
     }
 
@@ -48,9 +49,9 @@ public class MyQnaController {
     @AuthorizationRequired(value = {Role.USER,Role.ADMIN})
     @GetMapping("/bookmark")
     @ConvertToOneBase
-    public ResponseEntity<CustomPageDto<MyPageBookmark>> getMyPageBookMarkQnA(Pageable pageable) {
+    public ApiResponse<CustomPageDto<MyPageBookmark>> getMyPageBookMarkQnA(Pageable pageable) {
         Page<MyPageBookmark> bookmarkList = boardService.getMyPageBookMarkQuestion(pageable).map(MyPageBookmark::from);
 
-        return ResponseEntity.ok(CustomPageDto.of(bookmarkList));
+        return ApiResponse.ok(CustomPageDto.of(bookmarkList),"마이페이지 북마크한 QnA 질문 조회 완료");
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/code/controller/CodeController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/code/controller/CodeController.java
@@ -5,6 +5,7 @@ import com.gagoo.thiscoding.domain.mongo.code.controller.port.CodeService;
 import com.gagoo.thiscoding.domain.mongo.code.controller.response.CodeResponse;
 import com.gagoo.thiscoding.domain.mongo.code.domain.Code;
 import com.gagoo.thiscoding.domain.mongo.code.domain.dto.CodeCreate;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,23 +21,20 @@ public class CodeController {
     // 코드 파일 조회
     @GetMapping("/{codeId}")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CodeResponse> getCode(@PathVariable String codeId) {
+    public ApiResponse<CodeResponse> getCode(@PathVariable String codeId) {
         Code code = codeService.getById(codeId);
 
-        return ResponseEntity
-                .ok()
-                .body(CodeResponse.from(code));
+        return ApiResponse
+                .ok(CodeResponse.from(code), "코드 파일 조회 성공");
     }
 
     // 코드 파일 저장
     @PostMapping("/save")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CodeResponse> saveCode(@RequestBody CodeCreate codeCreate) {
+    public ApiResponse<CodeResponse> saveCode(@RequestBody CodeCreate codeCreate) {
         Code code = codeService.saveCode(codeCreate);
 
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(CodeResponse.from(code));
+        return ApiResponse.created(CodeResponse.from(code), "코드 파일 저장 성공");
     }
 
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/code/controller/CodeCreateController.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/code/controller/CodeCreateController.java
@@ -5,6 +5,7 @@ import com.gagoo.thiscoding.domain.mongo.code.controller.port.CodeService;
 import com.gagoo.thiscoding.domain.mongo.code.controller.response.CodeResponse;
 import com.gagoo.thiscoding.domain.mongo.code.domain.Code;
 import com.gagoo.thiscoding.domain.mongo.code.domain.dto.CodeCreate;
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import com.gagoo.thiscoding.global.security.aop.AuthorizationRequired;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,12 +21,11 @@ public class CodeCreateController {
     // 코드 파일 생성 (저장)
     @PostMapping("/create")
     @AuthorizationRequired(value = Role.USER)
-    public ResponseEntity<CodeResponse> createCode(@RequestBody CodeCreate codeCreate) {
+    public ApiResponse<CodeResponse> createCode(@RequestBody CodeCreate codeCreate) {
         Code code = codeService.createCode(codeCreate);
 
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .body(CodeResponse.from(code));
+        return ApiResponse
+                .created(CodeResponse.from(code),"코드 파일 생성 (저장) 성공");
     }
 
 }

--- a/src/main/java/com/gagoo/thiscoding/global/common/response/ApiResponse.java
+++ b/src/main/java/com/gagoo/thiscoding/global/common/response/ApiResponse.java
@@ -1,12 +1,31 @@
 package com.gagoo.thiscoding.global.common.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import com.gagoo.thiscoding.global.exception.GlobalException;
+import net.minidev.json.annotate.JsonIgnore;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
 
-@Getter
-@AllArgsConstructor
-public class ApiResponse<T> {
-    private boolean success;
-    private String message;
-    private T data;
+public record ApiResponse<T>(
+        @JsonIgnore HttpStatus httpStatus,
+        boolean success,
+        @Nullable String message,
+        @Nullable T data
+) {
+
+    public static <T> ApiResponse<T> ok(final T data, String message) {
+        return new ApiResponse<>(HttpStatus.OK, true, message, data);
+    }
+
+    public static <T> ApiResponse<T> created(final T data, String message) {
+        return new ApiResponse<>(HttpStatus.CREATED, true, message, data);
+    }
+
+    public static <T> ApiResponse<T> error(final HttpStatus status, String message, T data) {
+        return new ApiResponse<>(status, false, message,data);
+    }
+
+    public static <T> ApiResponse<T> error(final HttpStatus status, String message) {
+        return new ApiResponse<>(status, false, message,null);
+    }
+
 }

--- a/src/main/java/com/gagoo/thiscoding/global/common/response/ResponseInterceptor.java
+++ b/src/main/java/com/gagoo/thiscoding/global/common/response/ResponseInterceptor.java
@@ -1,0 +1,30 @@
+package com.gagoo.thiscoding.global.common.response;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ResponseInterceptor implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+                                  Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        if (returnType.getParameterType() == ApiResponse.class) {
+            HttpStatus status = ((ApiResponse<?>) body).httpStatus();
+            response.setStatusCode(status);
+        }
+
+        return body;
+    }
+}

--- a/src/main/java/com/gagoo/thiscoding/global/exception/GlobalizedResponseException.java
+++ b/src/main/java/com/gagoo/thiscoding/global/exception/GlobalizedResponseException.java
@@ -1,7 +1,7 @@
 package com.gagoo.thiscoding.global.exception;
 
+import com.gagoo.thiscoding.global.common.response.ApiResponse;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -14,27 +14,26 @@ import java.util.List;
 public class GlobalizedResponseException {
 
     @ExceptionHandler(GlobalException.class)
-    public final ResponseEntity<?> handleGlobalException(final GlobalException e, WebRequest request) {
+    public final ApiResponse<?> handleGlobalException(final GlobalException e, WebRequest request) {
 
-        return ResponseEntity
-                .status(e.getErrorCode().getStatus())
-                .body(
-                        new ExceptionResponse(e.getErrorCode().getMessage(),
-                                request.getDescription(false))
-                );
+        return ApiResponse.error(
+                e.getErrorCode().getStatus(),
+                e.getErrorCode().getMessage()
+        );
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, WebRequest request){
+    public ApiResponse<List<ExceptionResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, WebRequest request){
+
         List<ExceptionResponse> errors = new ArrayList<>();
 
-        e.getBindingResult().getAllErrors()
-                .forEach(c ->
-                        errors.add(new ExceptionResponse(c.getDefaultMessage(),
-                                request.getDescription(false)))
-                );
+        e.getBindingResult().getAllErrors().forEach(c -> {
+            errors.add(new ExceptionResponse(c.getDefaultMessage(),
+                    request.getDescription(false)));
+        });
 
-        return ResponseEntity.badRequest().body(errors);
+        return ApiResponse.error(HttpStatus.BAD_REQUEST, "유효성 검사에 실패하였습니다", errors);
+
     }
 
 }


### PR DESCRIPTION
ApiResponse.ok,created,error 구현

GlobalizedResponseException에서도 ResponseEntity 대신 ApiResponse 사용하도록 변경

[ResponseInterceptor 구현]
컨트롤러에서 ResponseEntity로 감싸지 않고 ApiResponse 타입으로 직접 반환 할 경우 
status가 200으로만 고정되어 전달되던 문제를 ResponseInterceptor를 통해 
 ApiResponse를 바로 반환하여 status 사용 할 수 있도록 변경