### PR TITLE
refactor: 답변 목록 조회 시, 추천 여부 조회로 발생되는 N + 1 문제 수정

### DIFF
--- a/src/main/java/com/gagoo/thiscoding/domain/maria/like/infrastructure/impl/LikeRepositoryImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/like/infrastructure/impl/LikeRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.gagoo.thiscoding.domain.maria.like.service.port.LikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -33,5 +34,10 @@ public class LikeRepositoryImpl implements LikeRepository {
     @Override
     public boolean existsByQnaIdAndUserId(String qnaId, Long userId) {
         return likeJpaRepository.existsByQnaIdAndUserId(qnaId, userId);
+    }
+
+    @Override
+    public List<String> findQnaIdsByQnaIdsAndUserId(List<String> qnaId, Long userId) {
+        return likeJpaRepository.findQnaIdsByQnaIdAndUserId(qnaId, userId);
     }
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/like/infrastructure/jpa/LikeJpaRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/like/infrastructure/jpa/LikeJpaRepository.java
@@ -2,10 +2,15 @@ package com.gagoo.thiscoding.domain.maria.like.infrastructure.jpa;
 
 import com.gagoo.thiscoding.domain.maria.like.infrastructure.LikeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeJpaRepository extends JpaRepository<LikeEntity, Long> {
     Optional<LikeEntity> findByQnaIdAndUserId(String qnaId, Long userId);
     boolean existsByQnaIdAndUserId(String qnaId, Long userId);
+
+    @Query("SELECT l.qnaId FROM LikeEntity l WHERE l.qnaId IN :qnaId AND l.user.id = :userId")
+    List<String> findQnaIdsByQnaIdAndUserId(List<String> qnaId, Long userId);
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/maria/like/service/port/LikeRepository.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/maria/like/service/port/LikeRepository.java
@@ -3,10 +3,12 @@ package com.gagoo.thiscoding.domain.maria.like.service.port;
 import com.gagoo.thiscoding.domain.maria.like.domain.Like;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface LikeRepository {
     Like save(Like like);
     Optional<Like> findByQnaIdAndUserId(String qnaId, Long userId);
     void deleteById(Long id);
     boolean existsByQnaIdAndUserId(String qnaId, Long userId);
+    List<String> findQnaIdsByQnaIdsAndUserId(List<String> qnaIds, Long userId);
 }

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.gagoo.thiscoding.domain.mongo.board.service;
 
 import com.gagoo.thiscoding.domain.maria.bookmark.service.port.BookmarkRepository;
+import com.gagoo.thiscoding.domain.maria.like.domain.Like;
 import com.gagoo.thiscoding.domain.maria.like.service.port.LikeRepository;
 import com.gagoo.thiscoding.domain.maria.reply.service.port.ReplyRepository;
 import com.gagoo.thiscoding.domain.maria.user.domain.User;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Builder
@@ -117,7 +119,6 @@ public class BoardServiceImpl implements BoardService {
                 .map(MyPageAnswerList::of);
     }
 
-
     /**
      * 마이페이지 내가 북마크한 QnA 질문 조회
      */
@@ -132,7 +133,6 @@ public class BoardServiceImpl implements BoardService {
         return boardRepository.findByIdIn(bookmarkedQnaIdList, pageable)
                 .map(MyPageBookMarkList::of);
     }
-
 
     /**
      * 게시판 전체목록 조회
@@ -151,19 +151,28 @@ public class BoardServiceImpl implements BoardService {
      */
     @Override
     public Page<AnswerList> findAnswersByQnaId(String qnaId, Pageable pageable) {
-        // 로그인 상태일 경우, 답변 추천 여부 조회
-        if(securityUtils.isLogin()) {
+        validateParentQnaExists(qnaId);
+
+        Page<Board> answers = boardRepository.findAnswerByQnaIdSortByIsSelected(qnaId, pageable);
+
+        if (securityUtils.isLogin()) {
             Long currentUserId = getCurrentUser().getId();
 
-            return boardRepository.findAnswerByQnaIdSortByIsSelected(qnaId, pageable)
-                    .map(board -> {
-                        boolean isLike = getIsLikeByQnaIdAndUserId(board.getId(), currentUserId);
-                        return AnswerList.from(board, isLike);
-                    });
+            // 답변 ID 목록 추출
+            List<String> answerIds = answers.getContent().stream()
+                    .map(Board::getId)
+                    .collect(Collectors.toList());
+
+            // 해당 답변 목록에 대한 좋아요 여부를 일괄 조회
+            List<String> likedAnswerIds= getLikedQnaIdsByAnwswerIdsAndUserId(answerIds, currentUserId);
+
+            return answers.map(board -> {
+                boolean isLike = likedAnswerIds.contains(board.getId());
+                return AnswerList.from(board, isLike);
+            });
         }
 
-        return boardRepository.findAnswerByQnaIdSortByIsSelected(qnaId, pageable)
-                .map(board -> AnswerList.from(board, false));
+        return answers.map(board -> AnswerList.from(board, false));
     }
 
     /**
@@ -191,12 +200,12 @@ public class BoardServiceImpl implements BoardService {
     private User getCurrentUser() {
         return userRepository.getByEmail(securityUtils.getUserEmail());
     }
-
+    
     /**
-     * 좋아요 여부 조회
+     * 좋아요 답변 ID 목록 조회
      */
-    private boolean getIsLikeByQnaIdAndUserId(String qnaId, Long userId) {
-        return likeRepository.existsByQnaIdAndUserId(qnaId, userId);
+    private List<String> getLikedQnaIdsByAnwswerIdsAndUserId(List<String> answerIds, Long userId) {
+        return likeRepository.findQnaIdsByQnaIdsAndUserId(answerIds, userId);
     }
 
     /**

--- a/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/gagoo/thiscoding/domain/mongo/board/service/BoardServiceImpl.java
@@ -158,14 +158,15 @@ public class BoardServiceImpl implements BoardService {
         if (securityUtils.isLogin()) {
             Long currentUserId = getCurrentUser().getId();
 
-            // 답변 ID 목록 추출
+            // 답변 ID 리스트
             List<String> answerIds = answers.getContent().stream()
                     .map(Board::getId)
                     .collect(Collectors.toList());
 
-            // 해당 답변 목록에 대한 좋아요 여부를 일괄 조회
+            // 해당 답변에 대한 추천 이력이 있는지 조회
             List<String> likedAnswerIds= getLikedQnaIdsByAnwswerIdsAndUserId(answerIds, currentUserId);
 
+            // 추천 여부를 반환값에 포함시켜 반환
             return answers.map(board -> {
                 boolean isLike = likedAnswerIds.contains(board.getId());
                 return AnswerList.from(board, isLike);

--- a/src/test/java/com/gagoo/thiscoding/domain/mock/FakeLikeRepository.java
+++ b/src/test/java/com/gagoo/thiscoding/domain/mock/FakeLikeRepository.java
@@ -43,4 +43,13 @@ public class FakeLikeRepository implements LikeRepository {
                 .anyMatch(like -> like.getQnaId().equals(qnaId)
                 && like.getUser().equals(userId));
     }
+
+    @Override
+    public List<String> findQnaIdsByQnaIdsAndUserId(List<String> qnaIds, Long userId) {
+        return data.stream()
+                .filter(like -> qnaIds.contains(like.getQnaId()) && like.getUser().equals(userId))
+                .map(Like::getQnaId)
+                .distinct()
+                .toList();
+    }
 }


### PR DESCRIPTION
**변경 사항**
--

- `LikeRepository`, `LikeRepositoryImpl`, `LikeJpaRepository` 내 `userId`가 일치하면서 여러 개의 `qnaId`와 동일한 `qnaId`를 반환하는 메서드 추가
- `BoardServiceImpl` 내 `findAnswersByQnaId` 메서드에서 각 답변에 대한 추천 여부를 조회하는 과정에서, 추천 여부를 조회하는 쿼리가 답변의 개수만큼 발생하는 N+1 문제가 발생했습니다. `BoardDocument`와 `LikeEntity`가 서로 다른 DB를 사용하기에 JOIN 문법을 이용한 쿼리는 불가능했습니다. 이를 해결하고자 조회한 답변 목록에서, 답변의 ID 값들을 일괄로 가져왔습니다. 가져온 답변 ID 값들을 이용해 `LikeEntity`에서 IN 문법을 이용한 쿼리로, 해당되는 값들을 가져왔습니다. 이렇게 가져온 추천 여부를 반환할 값인 `AnswerList`에 넣어주었습니다.